### PR TITLE
Enable adding employees through grid

### DIFF
--- a/WpfCheckerView/Services/IDepartmentService.cs
+++ b/WpfCheckerView/Services/IDepartmentService.cs
@@ -1,10 +1,10 @@
-using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using WpfCheckerView.Models;
 
 namespace WpfCheckerView.Services
 {
     public interface IDepartmentService
     {
-        IEnumerable<Department> GetDepartments();
+        ObservableCollection<Department> GetDepartments();
     }
 }

--- a/WpfCheckerView/Services/IEmployeeService.cs
+++ b/WpfCheckerView/Services/IEmployeeService.cs
@@ -1,10 +1,12 @@
-using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using WpfCheckerView.Models;
 
 namespace WpfCheckerView.Services
 {
     public interface IEmployeeService
     {
-        IEnumerable<Employee> GetEmployees();
+        ObservableCollection<Employee> GetEmployees();
+
+        void AddEmployee(Employee employee);
     }
 }

--- a/WpfCheckerView/Services/MockDataService.cs
+++ b/WpfCheckerView/Services/MockDataService.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using WpfCheckerView.Models;
 
 namespace WpfCheckerView.Services
@@ -8,19 +8,12 @@ namespace WpfCheckerView.Services
     /// </summary>
     public class MockDataService : IEmployeeService, IDepartmentService
     {
-        public IEnumerable<Employee> GetEmployees()
-        {
-            return new[]
-            {
-                new Employee { Id = 1, Name = "Alice", Department = "HR" },
-                new Employee { Id = 2, Name = "Bob", Department = "IT" },
-                new Employee { Id = 3, Name = "Charlie", Department = "Finance" }
-            };
-        }
+        private readonly ObservableCollection<Employee> _employees;
+        private readonly ObservableCollection<Department> _departments;
 
-        public IEnumerable<Department> GetDepartments()
+        public MockDataService()
         {
-            return new[]
+            _departments = new ObservableCollection<Department>
             {
                 new Department { Id = 1, Level = 1, Name = "Administration", Package = "A" },
                 new Department { Id = 2, Level = 2, Name = "IT", Package = "B" },
@@ -28,6 +21,22 @@ namespace WpfCheckerView.Services
                 new Department { Id = 4, Level = 1, Name = "HR", Package = "A" },
                 new Department { Id = 5, Level = 3, Name = "Sales", Package = "B" }
             };
+
+            _employees = new ObservableCollection<Employee>
+            {
+                new Employee { Id = 1, Name = "Alice", Department = "HR" },
+                new Employee { Id = 2, Name = "Bob", Department = "IT" },
+                new Employee { Id = 3, Name = "Charlie", Department = "Finance" }
+            };
+        }
+
+        public ObservableCollection<Employee> GetEmployees() => _employees;
+
+        public ObservableCollection<Department> GetDepartments() => _departments;
+
+        public void AddEmployee(Employee employee)
+        {
+            _employees.Add(employee);
         }
     }
 }

--- a/WpfCheckerView/ViewModels/MainViewModel.cs
+++ b/WpfCheckerView/ViewModels/MainViewModel.cs
@@ -11,10 +11,10 @@ namespace WpfCheckerView.ViewModels
         private readonly IDepartmentService _departmentService;
 
         [ObservableProperty]
-        private ObservableCollection<Employee> employees = new();
+        private ObservableCollection<Employee> employees = null!;
 
         [ObservableProperty]
-        private ObservableCollection<Department> departments = new();
+        private ObservableCollection<Department> departments = null!;
 
         public MainViewModel(IEmployeeService employeeService, IDepartmentService departmentService)
         {
@@ -25,8 +25,13 @@ namespace WpfCheckerView.ViewModels
 
         private void LoadData()
         {
-            Employees = new ObservableCollection<Employee>(_employeeService.GetEmployees());
-            Departments = new ObservableCollection<Department>(_departmentService.GetDepartments());
+            Employees = _employeeService.GetEmployees();
+            Departments = _departmentService.GetDepartments();
+        }
+
+        public void AddEmployee(Employee employee)
+        {
+            _employeeService.AddEmployee(employee);
         }
     }
 }

--- a/WpfCheckerView/Views/MainWindow.xaml
+++ b/WpfCheckerView/Views/MainWindow.xaml
@@ -8,7 +8,10 @@
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800">
     <Grid>
-        <syncfusion:SfDataGrid x:Name="dataGrid" AutoGenerateColumns="True" ItemsSource="{Binding Employees}">
+        <syncfusion:SfDataGrid x:Name="dataGrid" AutoGenerateColumns="True"
+                               ItemsSource="{Binding Employees}"
+                               AllowEditing="True"
+                               AddNewRowPosition="Top">
             <syncfusion:SfDataGrid.Columns>
                 <syncfusion:GridTextColumn MappingName="Id" HeaderText="ID" />
                 <syncfusion:GridTextColumn MappingName="Name" HeaderText="Name" />
@@ -16,7 +19,8 @@
                     MappingName="Department"
                     HeaderText="Department"
                     ItemsSource="{Binding DataContext.Departments, RelativeSource={RelativeSource AncestorType=Window}}"
-                    DisplayMemberPath="Name" />
+                    DisplayMemberPath="Name"
+                    ValueMemberPath="Name" />
             </syncfusion:SfDataGrid.Columns>
         </syncfusion:SfDataGrid>
     </Grid>


### PR DESCRIPTION
## Summary
- allow services to expose observable collections and new employee creation
- use shared collections in view model and expose an AddEmployee helper
- enable editing and add-new rows in the employee grid

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f40390e74832591af628e2a32c3ba