### PR TITLE
Add salary and identification fields to employee model and UI

### DIFF
--- a/WpfCheckerView/Models/Employee.cs
+++ b/WpfCheckerView/Models/Employee.cs
@@ -5,5 +5,8 @@ namespace WpfCheckerView.Models
         public int Id { get; set; }
         public string Name { get; set; } = string.Empty;
         public string Department { get; set; } = string.Empty;
+        public decimal Salary { get; set; }
+        public string IdProof { get; set; } = string.Empty;
+        public string PanNo { get; set; } = string.Empty;
     }
 }

--- a/WpfCheckerView/Services/MockDataService.cs
+++ b/WpfCheckerView/Services/MockDataService.cs
@@ -24,9 +24,9 @@ namespace WpfCheckerView.Services
 
             _employees = new ObservableCollection<Employee>
             {
-                new Employee { Id = 1, Name = "Alice", Department = "HR" },
-                new Employee { Id = 2, Name = "Bob", Department = "IT" },
-                new Employee { Id = 3, Name = "Charlie", Department = "Finance" }
+                new Employee { Id = 1, Name = "Alice", Department = "HR", Salary = 50000, IdProof = "ID123", PanNo = "PAN123" },
+                new Employee { Id = 2, Name = "Bob", Department = "IT", Salary = 60000, IdProof = "ID456", PanNo = "PAN456" },
+                new Employee { Id = 3, Name = "Charlie", Department = "Finance", Salary = 55000, IdProof = "ID789", PanNo = "PAN789" }
             };
         }
 

--- a/WpfCheckerView/ViewModels/MainViewModel.cs
+++ b/WpfCheckerView/ViewModels/MainViewModel.cs
@@ -26,6 +26,15 @@ namespace WpfCheckerView.ViewModels
         [ObservableProperty]
         private string newEmployeeDepartment = string.Empty;
 
+        [ObservableProperty]
+        private string newEmployeeSalary = string.Empty;
+
+        [ObservableProperty]
+        private string newEmployeeIdProof = string.Empty;
+
+        [ObservableProperty]
+        private string newEmployeePanNo = string.Empty;
+
         public MainViewModel(IEmployeeService employeeService, IDepartmentService departmentService)
         {
             _employeeService = employeeService;
@@ -49,12 +58,16 @@ namespace WpfCheckerView.ViewModels
         {
             if (string.IsNullOrWhiteSpace(NewEmployeeId) ||
                 string.IsNullOrWhiteSpace(NewEmployeeName) ||
-                string.IsNullOrWhiteSpace(NewEmployeeDepartment))
+                string.IsNullOrWhiteSpace(NewEmployeeDepartment) ||
+                string.IsNullOrWhiteSpace(NewEmployeeSalary) ||
+                string.IsNullOrWhiteSpace(NewEmployeeIdProof) ||
+                string.IsNullOrWhiteSpace(NewEmployeePanNo))
             {
                 return;
             }
 
-            if (!int.TryParse(NewEmployeeId, out var id))
+            if (!int.TryParse(NewEmployeeId, out var id) ||
+                !decimal.TryParse(NewEmployeeSalary, out var salary))
             {
                 return;
             }
@@ -63,7 +76,10 @@ namespace WpfCheckerView.ViewModels
             {
                 Id = id,
                 Name = NewEmployeeName,
-                Department = NewEmployeeDepartment
+                Department = NewEmployeeDepartment,
+                Salary = salary,
+                IdProof = NewEmployeeIdProof,
+                PanNo = NewEmployeePanNo
             };
 
             AddEmployee(employee);
@@ -71,6 +87,9 @@ namespace WpfCheckerView.ViewModels
             NewEmployeeId = string.Empty;
             NewEmployeeName = string.Empty;
             NewEmployeeDepartment = string.Empty;
+            NewEmployeeSalary = string.Empty;
+            NewEmployeeIdProof = string.Empty;
+            NewEmployeePanNo = string.Empty;
         }
     }
 }

--- a/WpfCheckerView/Views/MainWindow.xaml
+++ b/WpfCheckerView/Views/MainWindow.xaml
@@ -13,18 +13,36 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <StackPanel Orientation="Horizontal" Margin="10" Grid.Row="0">
-            <TextBlock Text="ID:" VerticalAlignment="Center" />
-            <TextBox Width="80" Margin="5,0" Text="{Binding NewEmployeeId, UpdateSourceTrigger=PropertyChanged}" />
-            <TextBlock Text="Name:" VerticalAlignment="Center" Margin="10,0,0,0" />
-            <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeName, UpdateSourceTrigger=PropertyChanged}" />
-            <TextBlock Text="Department:" VerticalAlignment="Center" Margin="10,0,0,0" />
-            <ComboBox Width="120" Margin="5,0"
-                      ItemsSource="{Binding Departments}"
-                      DisplayMemberPath="Name"
-                      SelectedValuePath="Name"
-                      SelectedValue="{Binding NewEmployeeDepartment, UpdateSourceTrigger=PropertyChanged}" />
-            <Button Content="Add" Margin="10,0,0,0" Command="{Binding AddNewEmployeeCommand}" />
+        <StackPanel Orientation="Vertical" Margin="10" Grid.Row="0">
+            <StackPanel Orientation="Horizontal" Margin="0,2">
+                <TextBlock Text="ID:" VerticalAlignment="Center" Width="100" />
+                <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeId, UpdateSourceTrigger=PropertyChanged}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,2">
+                <TextBlock Text="Name:" VerticalAlignment="Center" Width="100" />
+                <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeName, UpdateSourceTrigger=PropertyChanged}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,2">
+                <TextBlock Text="Department:" VerticalAlignment="Center" Width="100" />
+                <ComboBox Width="120" Margin="5,0"
+                          ItemsSource="{Binding Departments}"
+                          DisplayMemberPath="Name"
+                          SelectedValuePath="Name"
+                          SelectedValue="{Binding NewEmployeeDepartment, UpdateSourceTrigger=PropertyChanged}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,2">
+                <TextBlock Text="Salary:" VerticalAlignment="Center" Width="100" />
+                <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeSalary, UpdateSourceTrigger=PropertyChanged}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,2">
+                <TextBlock Text="ID Proof:" VerticalAlignment="Center" Width="100" />
+                <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeIdProof, UpdateSourceTrigger=PropertyChanged}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,2">
+                <TextBlock Text="Pan No.:" VerticalAlignment="Center" Width="100" />
+                <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeePanNo, UpdateSourceTrigger=PropertyChanged}" />
+            </StackPanel>
+            <Button Content="Add" Width="80" Margin="0,5" HorizontalAlignment="Left" Command="{Binding AddNewEmployeeCommand}" />
         </StackPanel>
 
         <syncfusion:SfDataGrid Grid.Row="1" x:Name="dataGrid" AutoGenerateColumns="True"
@@ -40,6 +58,9 @@
                     ItemsSource="{Binding DataContext.Departments, RelativeSource={RelativeSource AncestorType=Window}}"
                     DisplayMemberPath="Name"
                     ValueMemberPath="Name" />
+                <syncfusion:GridTextColumn MappingName="Salary" HeaderText="Salary" />
+                <syncfusion:GridTextColumn MappingName="IdProof" HeaderText="ID Proof" />
+                <syncfusion:GridTextColumn MappingName="PanNo" HeaderText="Pan No" />
             </syncfusion:SfDataGrid.Columns>
         </syncfusion:SfDataGrid>
     </Grid>


### PR DESCRIPTION
## Summary
- add Salary, Id Proof, and Pan No properties to Employee model
- wire up new employee fields in MainViewModel
- update UI layout to list each field on a separate line and show new columns
- seed mock data with sample salary and identification info

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f499ce4588325a3783fce4dd64e44