### PR TITLE
Replace StackPanel with Grid layout in MainWindow

### DIFF
--- a/WpfCheckerView/Views/MainWindow.xaml
+++ b/WpfCheckerView/Views/MainWindow.xaml
@@ -13,37 +13,47 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <StackPanel Orientation="Vertical" Margin="10" Grid.Row="0">
-            <StackPanel Orientation="Horizontal" Margin="0,2">
-                <TextBlock Text="ID:" VerticalAlignment="Center" Width="100" />
-                <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeId, UpdateSourceTrigger=PropertyChanged}" />
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0,2">
-                <TextBlock Text="Name:" VerticalAlignment="Center" Width="100" />
-                <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeName, UpdateSourceTrigger=PropertyChanged}" />
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0,2">
-                <TextBlock Text="Department:" VerticalAlignment="Center" Width="100" />
-                <ComboBox Width="120" Margin="5,0"
-                          ItemsSource="{Binding Departments}"
-                          DisplayMemberPath="Name"
-                          SelectedValuePath="Name"
-                          SelectedValue="{Binding NewEmployeeDepartment, UpdateSourceTrigger=PropertyChanged}" />
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0,2">
-                <TextBlock Text="Salary:" VerticalAlignment="Center" Width="100" />
-                <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeSalary, UpdateSourceTrigger=PropertyChanged}" />
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0,2">
-                <TextBlock Text="ID Proof:" VerticalAlignment="Center" Width="100" />
-                <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeIdProof, UpdateSourceTrigger=PropertyChanged}" />
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0,2">
-                <TextBlock Text="Pan No.:" VerticalAlignment="Center" Width="100" />
-                <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeePanNo, UpdateSourceTrigger=PropertyChanged}" />
-            </StackPanel>
-            <Button Content="Add" Width="80" Margin="0,5" HorizontalAlignment="Left" Command="{Binding AddNewEmployeeCommand}" />
-        </StackPanel>
+        <Grid Margin="10" Grid.Row="0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Text="ID:" VerticalAlignment="Center" Width="100" Grid.Row="0" Grid.Column="0" />
+            <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeId, UpdateSourceTrigger=PropertyChanged}" Grid.Row="0" Grid.Column="1" />
+
+            <TextBlock Text="Name:" VerticalAlignment="Center" Width="100" Grid.Row="1" Grid.Column="0" />
+            <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeName, UpdateSourceTrigger=PropertyChanged}" Grid.Row="1" Grid.Column="1" />
+
+            <TextBlock Text="Department:" VerticalAlignment="Center" Width="100" Grid.Row="2" Grid.Column="0" />
+            <ComboBox Width="120" Margin="5,0"
+                      ItemsSource="{Binding Departments}"
+                      DisplayMemberPath="Name"
+                      SelectedValuePath="Name"
+                      SelectedValue="{Binding NewEmployeeDepartment, UpdateSourceTrigger=PropertyChanged}"
+                      Grid.Row="2" Grid.Column="1" />
+
+            <TextBlock Text="Salary:" VerticalAlignment="Center" Width="100" Grid.Row="3" Grid.Column="0" />
+            <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeSalary, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1" />
+
+            <TextBlock Text="ID Proof:" VerticalAlignment="Center" Width="100" Grid.Row="4" Grid.Column="0" />
+            <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeIdProof, UpdateSourceTrigger=PropertyChanged}" Grid.Row="4" Grid.Column="1" />
+
+            <TextBlock Text="Pan No.:" VerticalAlignment="Center" Width="100" Grid.Row="5" Grid.Column="0" />
+            <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeePanNo, UpdateSourceTrigger=PropertyChanged}" Grid.Row="5" Grid.Column="1" />
+
+            <Button Content="Add" Width="80" Margin="0,5" HorizontalAlignment="Left"
+                    Command="{Binding AddNewEmployeeCommand}" Grid.Row="6" Grid.Column="1" />
+        </Grid>
 
         <syncfusion:SfDataGrid Grid.Row="1" x:Name="dataGrid" AutoGenerateColumns="True"
                                ItemsSource="{Binding Employees}"


### PR DESCRIPTION
## Summary
- use a Grid-based layout for the employee form instead of nested StackPanels

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f4c5b24a083259c84709fc53ca958