### PR TITLE
Add unit test project for MockDataService

### DIFF
--- a/WpfChecker.sln
+++ b/WpfChecker.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36301.6 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfCheckerView", "WpfCheckerView\WpfCheckerView.csproj", "{D1BCC1A7-8E23-4B1B-BB59-7CAE6EB3A7B1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfCheckerView.Tests", "WpfCheckerView.Tests\WpfCheckerView.Tests.csproj", "{C12E0D7F-89DC-4AE9-AEC9-F89DE923B731}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{D1BCC1A7-8E23-4B1B-BB59-7CAE6EB3A7B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1BCC1A7-8E23-4B1B-BB59-7CAE6EB3A7B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1BCC1A7-8E23-4B1B-BB59-7CAE6EB3A7B1}.Release|Any CPU.Build.0 = Release|Any CPU
+                {C12E0D7F-89DC-4AE9-AEC9-F89DE923B731}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {C12E0D7F-89DC-4AE9-AEC9-F89DE923B731}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {C12E0D7F-89DC-4AE9-AEC9-F89DE923B731}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {C12E0D7F-89DC-4AE9-AEC9-F89DE923B731}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WpfCheckerView.Tests/Services/MockDataServiceTests.cs
+++ b/WpfCheckerView.Tests/Services/MockDataServiceTests.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using WpfCheckerView.Models;
+using WpfCheckerView.Services;
+using Xunit;
+
+namespace WpfCheckerView.Tests.Services;
+
+public class MockDataServiceTests
+{
+    [Fact]
+    public void GetEmployees_ShouldReturnSeededEmployees()
+    {
+        var service = new MockDataService();
+
+        var employees = service.GetEmployees();
+
+        Assert.NotNull(employees);
+        Assert.Equal(3, employees.Count);
+    }
+
+    [Fact]
+    public void AddEmployee_ShouldIncreaseEmployeeCount()
+    {
+        var service = new MockDataService();
+        var newEmployee = new Employee
+        {
+            Id = 4,
+            Name = "David",
+            Department = "IT",
+            Salary = 65000,
+            IdProof = "ID000",
+            PanNo = "PAN000"
+        };
+
+        service.AddEmployee(newEmployee);
+
+        Assert.Equal(4, service.GetEmployees().Count);
+        Assert.Contains(service.GetEmployees(), e => e.Id == 4 && e.Name == "David");
+    }
+
+    [Fact]
+    public void GetDepartments_ShouldReturnSeededDepartments()
+    {
+        var service = new MockDataService();
+
+        var departments = service.GetDepartments();
+
+        Assert.NotNull(departments);
+        Assert.Equal(5, departments.Count);
+    }
+}

--- a/WpfCheckerView.Tests/WpfCheckerView.Tests.csproj
+++ b/WpfCheckerView.Tests/WpfCheckerView.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\WpfCheckerView\\WpfCheckerView.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add xUnit test project
- cover MockDataService employees and departments operations

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f4ccdc86883259a51ae934e9dab87