### PR TITLE
Add reusable DoubleTextBox control

### DIFF
--- a/CustomControls/CustomControls.csproj
+++ b/CustomControls/CustomControls.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+</Project>

--- a/CustomControls/DoubleTextBox.cs
+++ b/CustomControls/DoubleTextBox.cs
@@ -1,0 +1,144 @@
+using System;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Markup;
+
+namespace CustomControls;
+
+/// <summary>
+/// TextBox that accepts only numeric double values.
+/// </summary>
+[DefaultProperty(nameof(Text))]
+[ContentProperty(nameof(Text))]
+public class DoubleTextBox : TextBox
+{
+    static DoubleTextBox()
+    {
+        // enable preview text input for numbers
+    }
+
+    public DoubleTextBox()
+    {
+        DataObject.AddPastingHandler(this, OnPaste);
+    }
+
+    /// <summary>
+    /// Gets or sets whether negative values are allowed.
+    /// </summary>
+    [DefaultValue(true)]
+    public bool AllowNegative
+    {
+        get => (bool)GetValue(AllowNegativeProperty);
+        set => SetValue(AllowNegativeProperty, value);
+    }
+
+    public static readonly DependencyProperty AllowNegativeProperty =
+        DependencyProperty.Register(nameof(AllowNegative), typeof(bool), typeof(DoubleTextBox), new PropertyMetadata(true));
+
+    /// <summary>
+    /// Gets or sets the minimum allowed value.
+    /// </summary>
+    public double MinValue
+    {
+        get => (double)GetValue(MinValueProperty);
+        set => SetValue(MinValueProperty, value);
+    }
+
+    public static readonly DependencyProperty MinValueProperty =
+        DependencyProperty.Register(nameof(MinValue), typeof(double), typeof(DoubleTextBox), new PropertyMetadata(double.MinValue));
+
+    /// <summary>
+    /// Gets or sets the maximum allowed value.
+    /// </summary>
+    public double MaxValue
+    {
+        get => (double)GetValue(MaxValueProperty);
+        set => SetValue(MaxValueProperty, value);
+    }
+
+    public static readonly DependencyProperty MaxValueProperty =
+        DependencyProperty.Register(nameof(MaxValue), typeof(double), typeof(DoubleTextBox), new PropertyMetadata(double.MaxValue));
+
+    /// <summary>
+    /// Gets or sets the numeric value represented by the control.
+    /// </summary>
+    public double Value
+    {
+        get => (double)GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+
+    public static readonly DependencyProperty ValueProperty =
+        DependencyProperty.Register(
+            nameof(Value), typeof(double), typeof(DoubleTextBox),
+            new FrameworkPropertyMetadata(0d, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnValueChanged));
+
+    private static void OnValueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var control = (DoubleTextBox)d;
+        var newValue = (double)e.NewValue;
+        control.Text = newValue.ToString();
+    }
+
+    protected override void OnPreviewTextInput(TextCompositionEventArgs e)
+    {
+        base.OnPreviewTextInput(e);
+
+        var proposed = Text.Insert(CaretIndex, e.Text);
+        if (!IsTextValid(proposed))
+        {
+            e.Handled = true;
+        }
+    }
+
+    protected override void OnTextChanged(TextChangedEventArgs e)
+    {
+        base.OnTextChanged(e);
+        if (double.TryParse(Text, out var value))
+        {
+            value = Math.Max(MinValue, Math.Min(MaxValue, value));
+            Value = value;
+        }
+    }
+
+    private bool IsTextValid(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return true;
+
+        if (text == "-")
+            return AllowNegative;
+
+        if (!AllowNegative && text.Contains("-"))
+            return false;
+
+        if (text.StartsWith("."))
+            text = "0" + text;
+
+        if (double.TryParse(text, out var value))
+        {
+            return value >= MinValue && value <= MaxValue;
+        }
+
+        return false;
+    }
+
+    private void OnPaste(object sender, DataObjectPastingEventArgs e)
+    {
+        if (e.DataObject.GetDataPresent(DataFormats.Text))
+        {
+            var pasted = e.DataObject.GetData(DataFormats.Text) as string ?? string.Empty;
+            var proposed = Text.Insert(CaretIndex, pasted);
+            if (!IsTextValid(proposed))
+            {
+                e.CancelCommand();
+            }
+        }
+        else
+        {
+            e.CancelCommand();
+        }
+    }
+}

--- a/WpfChecker.sln
+++ b/WpfChecker.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfCheckerView", "WpfChecke
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfCheckerView.Tests", "WpfCheckerView.Tests\WpfCheckerView.Tests.csproj", "{C12E0D7F-89DC-4AE9-AEC9-F89DE923B731}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CustomControls", "CustomControls\CustomControls.csproj", "{F7159E01-D4F5-478E-B464-9BA5C10EA4F9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
                 {C12E0D7F-89DC-4AE9-AEC9-F89DE923B731}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {C12E0D7F-89DC-4AE9-AEC9-F89DE923B731}.Release|Any CPU.ActiveCfg = Release|Any CPU
                 {C12E0D7F-89DC-4AE9-AEC9-F89DE923B731}.Release|Any CPU.Build.0 = Release|Any CPU
+                {F7159E01-D4F5-478E-B464-9BA5C10EA4F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {F7159E01-D4F5-478E-B464-9BA5C10EA4F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {F7159E01-D4F5-478E-B464-9BA5C10EA4F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {F7159E01-D4F5-478E-B464-9BA5C10EA4F9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add CustomControls project for reusable WPF components
- implement DoubleTextBox control that accepts only numeric double values
- register new project in solution

## Testing
- `apt-get update`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f55254aac83258370259801167290