### PR TITLE
Use DoubleTextBox for salary input

### DIFF
--- a/WpfCheckerView/Views/MainWindow.xaml
+++ b/WpfCheckerView/Views/MainWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
         xmlns:local="clr-namespace:WpfCheckerView.Views"
+        xmlns:controls="clr-namespace:CustomControls;assembly=CustomControls"
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800">
     <Grid>
@@ -43,7 +44,7 @@
                       Grid.Row="2" Grid.Column="1" />
 
             <TextBlock Text="Salary:" VerticalAlignment="Center" Width="100" Grid.Row="3" Grid.Column="0" />
-            <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeSalary, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1" />
+            <controls:DoubleTextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeSalary, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1" />
 
             <TextBlock Text="ID Proof:" VerticalAlignment="Center" Width="100" Grid.Row="4" Grid.Column="0" />
             <TextBox Width="120" Margin="5,0" Text="{Binding NewEmployeeIdProof, UpdateSourceTrigger=PropertyChanged}" Grid.Row="4" Grid.Column="1" />

--- a/WpfCheckerView/WpfCheckerView.csproj
+++ b/WpfCheckerView/WpfCheckerView.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="Syncfusion.SfGrid.WPF" Version="29.1.41" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\CustomControls\CustomControls.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- allow usage of custom DoubleTextBox control in app
- restrict salary entry to numeric values using DoubleTextBox

## Testing
- `dotnet test` *(fails: command not found)*
- `curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f603eac408325aaf85d0fd37e3952