### PR TITLE
Handle backspace across literals in PatternTextBox

### DIFF
--- a/CustomControls/PatternTextBox.cs
+++ b/CustomControls/PatternTextBox.cs
@@ -99,6 +99,48 @@ public class PatternTextBox : TextBox
             e.Handled = true;
     }
 
+    protected override void OnPreviewKeyDown(KeyEventArgs e)
+    {
+        if (_mask is not null && SelectionLength == 0 && (e.Key == Key.Back || e.Key == Key.Delete))
+        {
+            var rawCaret = GetRawCaretIndex();
+            var raw = GetRawText();
+
+            if (e.Key == Key.Back)
+            {
+                if (rawCaret == 0)
+                {
+                    e.Handled = true;
+                    return;
+                }
+                raw = raw.Remove(rawCaret - 1, 1);
+                rawCaret--;
+            }
+            else // Delete
+            {
+                if (rawCaret >= raw.Length)
+                {
+                    e.Handled = true;
+                    return;
+                }
+                raw = raw.Remove(rawCaret, 1);
+            }
+
+            _isFormatting = true;
+            raw = FilterRaw(raw);
+            var (formatted, caret) = ApplyMask(raw, rawCaret);
+            Text = formatted;
+            CaretIndex = caret;
+            _isFormatting = false;
+            UpdateIsValid();
+
+            e.Handled = true;
+            return;
+        }
+
+        base.OnPreviewKeyDown(e);
+    }
+
     protected override void OnTextChanged(TextChangedEventArgs e)
     {
         base.OnTextChanged(e);

--- a/WpfCheckerView.Tests/PatternTextBoxTests.cs
+++ b/WpfCheckerView.Tests/PatternTextBoxTests.cs
@@ -1,0 +1,59 @@
+using CustomControls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows;
+using Xunit;
+
+namespace WpfCheckerView.Tests;
+
+public class PatternTextBoxTests
+{
+    [Fact]
+    public void Backspace_Should_Remove_Character_Before_Literal()
+    {
+        var tb = new TestPatternTextBox { Pattern = @"^\d{3}-\d{3}$" };
+        tb.Type("1234"); // results in 123-4
+
+        tb.PressBackspace(); // remove 4 -> 123-
+        tb.PressBackspace(); // remove 3 and hyphen -> 12
+
+        Assert.Equal("12", tb.Text);
+    }
+
+    private class TestPatternTextBox : PatternTextBox
+    {
+        public void Type(string text)
+        {
+            foreach (var ch in text)
+            {
+                var composition = new TextComposition(InputManager.Current, this, ch.ToString());
+                var args = new TextCompositionEventArgs(InputManager.Current.PrimaryKeyboardDevice, composition)
+                {
+                    RoutedEvent = TextCompositionManager.PreviewTextInputEvent
+                };
+                OnPreviewTextInput(args);
+                if (!args.Handled)
+                {
+                    Text = Text.Insert(CaretIndex, ch.ToString());
+                    CaretIndex++;
+                }
+            }
+        }
+
+        public void PressBackspace()
+        {
+            var args = new KeyEventArgs(Keyboard.PrimaryDevice, new TestPresentationSource(), 0, Key.Back)
+            {
+                RoutedEvent = Keyboard.PreviewKeyDownEvent
+            };
+            OnPreviewKeyDown(args);
+        }
+    }
+
+    private class TestPresentationSource : PresentationSource
+    {
+        public override Visual RootVisual { get => null!; set { } }
+        protected override CompositionTarget? GetCompositionTargetCore() => null;
+        public override bool IsDisposed => false;
+    }
+}

--- a/WpfCheckerView.Tests/WpfCheckerView.Tests.csproj
+++ b/WpfCheckerView.Tests/WpfCheckerView.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0-windows7.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- allow deleting over spaces and hyphens in PatternTextBox
- add regression test ensuring backspace skips mask literals
- enable WPF in test project

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f7133a6c883259094e00cc0270996