### PR TITLE
Add payment balance user control and tests

### DIFF
--- a/WpfCheckerView.Tests/PaymentBalanceViewModelTests.cs
+++ b/WpfCheckerView.Tests/PaymentBalanceViewModelTests.cs
@@ -1,0 +1,23 @@
+using WpfCheckerView.ViewModels;
+using WpfCheckerView.Models;
+using Xunit;
+
+namespace WpfCheckerView.Tests
+{
+    public class PaymentBalanceViewModelTests
+    {
+        [Fact]
+        public void RemainingAmountUpdatesWithPayments()
+        {
+            var vm = new PaymentBalanceViewModel { TotalAmount = 100m };
+            vm.PaymentMethods.Add(new PaymentMethodEntry { Method = "Cash", Amount = 40m });
+            vm.PaymentMethods.Add(new PaymentMethodEntry { Method = "Card", Amount = 30m });
+
+            Assert.Equal(30m, vm.RemainingAmount);
+
+            vm.PaymentMethods[0].Amount = 50m;
+
+            Assert.Equal(20m, vm.RemainingAmount);
+        }
+    }
+}

--- a/WpfCheckerView/Models/PaymentMethodEntry.cs
+++ b/WpfCheckerView/Models/PaymentMethodEntry.cs
@@ -1,0 +1,13 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace WpfCheckerView.Models
+{
+    public partial class PaymentMethodEntry : ObservableObject
+    {
+        [ObservableProperty]
+        private string method = string.Empty;
+
+        [ObservableProperty]
+        private decimal amount;
+    }
+}

--- a/WpfCheckerView/ViewModels/MainViewModel.cs
+++ b/WpfCheckerView/ViewModels/MainViewModel.cs
@@ -35,10 +35,14 @@ namespace WpfCheckerView.ViewModels
         [ObservableProperty]
         private string newEmployeePanNo = string.Empty;
 
+        [ObservableProperty]
+        private PaymentBalanceViewModel paymentBalance = new();
+
         public MainViewModel(IEmployeeService employeeService, IDepartmentService departmentService)
         {
             _employeeService = employeeService;
             _departmentService = departmentService;
+            PaymentBalance.TotalAmount = 0m;
             LoadData();
         }
 

--- a/WpfCheckerView/ViewModels/PaymentBalanceViewModel.cs
+++ b/WpfCheckerView/ViewModels/PaymentBalanceViewModel.cs
@@ -1,0 +1,55 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using WpfCheckerView.Models;
+
+namespace WpfCheckerView.ViewModels
+{
+    public partial class PaymentBalanceViewModel : ObservableObject
+    {
+        [ObservableProperty]
+        private decimal totalAmount;
+
+        public ObservableCollection<PaymentMethodEntry> PaymentMethods { get; } = new();
+
+        public decimal RemainingAmount => TotalAmount - PaymentMethods.Sum(pm => pm.Amount);
+
+        public PaymentBalanceViewModel()
+        {
+            PaymentMethods.CollectionChanged += PaymentMethods_CollectionChanged;
+        }
+
+        private void PaymentMethods_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            if (e.NewItems != null)
+            {
+                foreach (PaymentMethodEntry item in e.NewItems)
+                {
+                    item.PropertyChanged += PaymentMethod_PropertyChanged;
+                }
+            }
+            if (e.OldItems != null)
+            {
+                foreach (PaymentMethodEntry item in e.OldItems)
+                {
+                    item.PropertyChanged -= PaymentMethod_PropertyChanged;
+                }
+            }
+            OnPropertyChanged(nameof(RemainingAmount));
+        }
+
+        private void PaymentMethod_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(PaymentMethodEntry.Amount))
+            {
+                OnPropertyChanged(nameof(RemainingAmount));
+            }
+        }
+
+        partial void OnTotalAmountChanged(decimal value)
+        {
+            OnPropertyChanged(nameof(RemainingAmount));
+        }
+    }
+}

--- a/WpfCheckerView/Views/MainWindow.xaml
+++ b/WpfCheckerView/Views/MainWindow.xaml
@@ -56,23 +56,34 @@
                     Command="{Binding AddNewEmployeeCommand}" Grid.Row="6" Grid.Column="1" />
         </Grid>
 
-        <syncfusion:SfDataGrid Grid.Row="1" x:Name="dataGrid" AutoGenerateColumns="True"
-                               ItemsSource="{Binding Employees}"
-                               AllowEditing="True"
-                               AddNewRowPosition="Top">
-            <syncfusion:SfDataGrid.Columns>
-                <syncfusion:GridTextColumn MappingName="Id" HeaderText="ID" />
-                <syncfusion:GridTextColumn MappingName="Name" HeaderText="Name" />
-                <syncfusion:GridComboBoxColumn
-                    MappingName="Department"
-                    HeaderText="Department"
-                    ItemsSource="{Binding DataContext.Departments, RelativeSource={RelativeSource AncestorType=Window}}"
-                    DisplayMemberPath="Name"
-                    SelectedValuePath="Name" />
-                <syncfusion:GridTextColumn MappingName="Salary" HeaderText="Salary" />
-                <syncfusion:GridTextColumn MappingName="IdProof" HeaderText="ID Proof" />
-                <syncfusion:GridTextColumn MappingName="PanNo" HeaderText="Pan No" />
-            </syncfusion:SfDataGrid.Columns>
-        </syncfusion:SfDataGrid>
+        <Grid Grid.Row="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <syncfusion:SfDataGrid Grid.Row="0" x:Name="dataGrid" AutoGenerateColumns="True"
+                                   ItemsSource="{Binding Employees}"
+                                   AllowEditing="True"
+                                   AddNewRowPosition="Top">
+                <syncfusion:SfDataGrid.Columns>
+                    <syncfusion:GridTextColumn MappingName="Id" HeaderText="ID" />
+                    <syncfusion:GridTextColumn MappingName="Name" HeaderText="Name" />
+                    <syncfusion:GridComboBoxColumn
+                        MappingName="Department"
+                        HeaderText="Department"
+                        ItemsSource="{Binding DataContext.Departments, RelativeSource={RelativeSource AncestorType=Window}}"
+                        DisplayMemberPath="Name"
+                        SelectedValuePath="Name" />
+                    <syncfusion:GridTextColumn MappingName="Salary" HeaderText="Salary" />
+                    <syncfusion:GridTextColumn MappingName="IdProof" HeaderText="ID Proof" />
+                    <syncfusion:GridTextColumn MappingName="PanNo" HeaderText="Pan No" />
+                </syncfusion:SfDataGrid.Columns>
+            </syncfusion:SfDataGrid>
+
+            <Expander Grid.Row="1" Header="Payment Methods">
+                <local:PaymentBalanceControl DataContext="{Binding PaymentBalance}" />
+            </Expander>
+        </Grid>
     </Grid>
 </Window>

--- a/WpfCheckerView/Views/PaymentBalanceControl.xaml
+++ b/WpfCheckerView/Views/PaymentBalanceControl.xaml
@@ -1,0 +1,31 @@
+<UserControl x:Class="WpfCheckerView.Views.PaymentBalanceControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+    <Grid Margin="5">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Text="Total Amount:" Grid.Row="0" Grid.Column="0" Margin="0,0,5,5" VerticalAlignment="Center" />
+        <TextBlock Text="{Binding TotalAmount, StringFormat={}{0:C}}" Grid.Row="0" Grid.Column="1" Margin="0,0,0,5" VerticalAlignment="Center" />
+
+        <DataGrid Grid.Row="1" Grid.ColumnSpan="2" ItemsSource="{Binding PaymentMethods}" AutoGenerateColumns="False" CanUserAddRows="True" Margin="0,0,0,5">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Method" Binding="{Binding Method, UpdateSourceTrigger=PropertyChanged}" />
+                <DataGridTextColumn Header="Amount" Binding="{Binding Amount, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:N2}}" />
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <TextBlock Text="Remaining:" Grid.Row="2" Grid.Column="0" Margin="0,0,5,0" VerticalAlignment="Center" />
+        <TextBlock Text="{Binding RemainingAmount, StringFormat={}{0:C}}" Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" />
+    </Grid>
+</UserControl>

--- a/WpfCheckerView/Views/PaymentBalanceControl.xaml.cs
+++ b/WpfCheckerView/Views/PaymentBalanceControl.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace WpfCheckerView.Views
+{
+    public partial class PaymentBalanceControl : UserControl
+    {
+        public PaymentBalanceControl()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add PaymentBalanceControl user control with grid layout to split a total into payment methods
- Introduce PaymentBalanceViewModel and PaymentMethodEntry models to track payment distribution
- Integrate control into MainWindow inside an Expander
- Add unit test for PaymentBalanceViewModel remaining amount logic

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a808e3511c8325b17553826103b2c3