### PR TITLE
Fix TransactionContra total calculation and add tests

### DIFF
--- a/WpfCheckerView.Tests/TransactionContraTests.cs
+++ b/WpfCheckerView.Tests/TransactionContraTests.cs
@@ -1,0 +1,43 @@
+using WpfCheckerView.Models;
+using WpfCheckerView.ViewModels;
+using Xunit;
+
+namespace WpfCheckerView.Tests
+{
+    public class TransactionContraTests
+    {
+        [Fact]
+        public void TotalSum_HandlesNullValues()
+        {
+            var contra = new TransactionContra();
+            Assert.Equal(0m, contra.TotalSum());
+        }
+
+        [Fact]
+        public void TotalSum_SumsProvidedValues()
+        {
+            var contra = new TransactionContra
+            {
+                SuspenseAmt = 10,
+                ChequeAmt = 5,
+                TrAmount = 15,
+                SdAmount = 20
+            };
+
+            Assert.Equal(50m, contra.TotalSum());
+        }
+
+        [Fact]
+        public void RemainingAmount_UsesTransactionContraTotal()
+        {
+            var vm = new PaymentBalanceViewModel
+            {
+                TotalAmount = 100m
+            };
+            vm.TransContra.SuspenseAmt = 10;
+            vm.TransContra.ChequeAmt = 5;
+
+            Assert.Equal(85m, vm.RemainingAmount);
+        }
+    }
+}

--- a/WpfCheckerView/Models/TransactionContra.cs
+++ b/WpfCheckerView/Models/TransactionContra.cs
@@ -27,7 +27,10 @@ namespace WpfCheckerView.Models
 
         internal decimal TotalSum()
         {
-            return  (decimal?)SuspenseAmt + (decimal?)ChequeAmt + (decimal?)TrAmount + (decimal?)SdAmount ?? 0;
+            return (decimal)((SuspenseAmt ?? 0) +
+                             (ChequeAmt ?? 0) +
+                             (TrAmount ?? 0) +
+                             (SdAmount ?? 0));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Correct TransactionContra.TotalSum to safely sum nullable values
- Add unit tests for TransactionContra and PaymentBalanceViewModel integration

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a837d2eab48325af6db6d34c04cf7d