### PR TITLE
Use STA-aware xUnit attribute for PatternTextBox test

### DIFF
--- a/WpfCheckerView.Tests/PatternTextBoxTests.cs
+++ b/WpfCheckerView.Tests/PatternTextBoxTests.cs
@@ -8,7 +8,7 @@ namespace WpfCheckerView.Tests;
 
 public class PatternTextBoxTests
 {
-    [Fact]
+    [StaFact]
     public void Backspace_Should_Remove_Character_Before_Literal()
     {
         var tb = new TestPatternTextBox { Pattern = @"^\d{3}-\d{3}$" };

--- a/WpfCheckerView.Tests/WpfCheckerView.Tests.csproj
+++ b/WpfCheckerView.Tests/WpfCheckerView.Tests.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.StaFact" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- ensure `PatternTextBox` unit test runs in a single-threaded apartment by referencing `Xunit.StaFact`
- mark the test with `[StaFact]` to construct WPF controls safely

## Testing
- `dotnet test WpfCheckerView.Tests/WpfCheckerView.Tests.csproj -l "console;verbosity=normal" --filter "Backspace_Should_Remove_Character_Before_Literal"` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a84b66f2208325a81f418b27ab13ca