### PR TITLE
Add expander for other heads with single-open enforcement

### DIFF
--- a/WpfCheckerView.Tests/TransactionContraTests.cs
+++ b/WpfCheckerView.Tests/TransactionContraTests.cs
@@ -28,6 +28,29 @@ namespace WpfCheckerView.Tests
         }
 
         [Fact]
+        public void TotalSum_IncludesOtherTransactionDetails()
+        {
+            var contra = new TransactionContra
+            {
+                ChequeAmt = 10
+            };
+            contra.OtherTranDetails.Add(new TransactionDetail { AdjAmount = 5 });
+            contra.OtherTranDetails.Add(new TransactionDetail { AdjAmount = 15 });
+
+            Assert.Equal(30m, contra.TotalSum());
+        }
+
+        [Fact]
+        public void OtherHeadsAmount_SumsDetails()
+        {
+            var contra = new TransactionContra();
+            contra.OtherTranDetails.Add(new TransactionDetail { AdjAmount = 2 });
+            contra.OtherTranDetails.Add(new TransactionDetail { AdjAmount = 3 });
+
+            Assert.Equal(5m, contra.OtherHeadsAmount);
+        }
+
+        [Fact]
         public void RemainingAmount_UsesTransactionContraTotal()
         {
             var vm = new PaymentBalanceViewModel

--- a/WpfCheckerView/Models/TransactionContra.cs
+++ b/WpfCheckerView/Models/TransactionContra.cs
@@ -23,14 +23,16 @@ namespace WpfCheckerView.Models
         public string? SdAccountId { get; set; }
         public double? SdAmount { get; set; }
         public string? Remarks { get; set; }
-        public ObservableCollection<TransactionDetail> OtherTranDetails { get; set; }
+        public ObservableCollection<TransactionDetail> OtherTranDetails { get; set; } = new();
+
+        public decimal OtherHeadsAmount => OtherTranDetails.Sum(d => (decimal)(d.AdjAmount ?? 0));
 
         public decimal TotalSum()
         {
             return (decimal)((SuspenseAmt ?? 0) +
                              (ChequeAmt ?? 0) +
                              (TrAmount ?? 0) +
-                             (SdAmount ?? 0));
+                             (SdAmount ?? 0)) + OtherHeadsAmount;
         }
     }
 }

--- a/WpfCheckerView/Views/PaymentBalanceControl.xaml
+++ b/WpfCheckerView/Views/PaymentBalanceControl.xaml
@@ -18,16 +18,20 @@
         <TextBlock Text="Total Amount:" Grid.Row="0" Grid.Column="0" Margin="0,0,5,5" VerticalAlignment="Center" />
         <TextBlock Text="{Binding TotalAmount, StringFormat={}{0:C}}" Grid.Row="0" Grid.Column="1" Margin="0,0,0,5" VerticalAlignment="Center" />
 
-        <TabControl  Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" >
-            <TabItem Header="To Cheque">
+        <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2">
+            <Expander x:Name="ChequeExpander" Margin="0,0,0,5" Expanded="Expander_Expanded">
+                <Expander.Header>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="To Cheque" FontWeight="Bold" />
+                        <TextBlock Text="{Binding TransContra.ChequeAmt, StringFormat={}{0:C}}" Margin="10,0,0,0" />
+                    </StackPanel>
+                </Expander.Header>
                 <Grid Margin="5">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -38,15 +42,22 @@
                     <TextBlock Text="Bank Name:" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0" />
                     <TextBox Text="{Binding TransContra.BankName, UpdateSourceTrigger=PropertyChanged}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5" />
                     <TextBlock Text="Cheque Date:" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0" />
-                    <DatePicker Text="{Binding TransContra.ChequeDate, UpdateSourceTrigger=PropertyChanged, StringFormat='{}{0:dd/MM/yyyy}'}" 
-                             Grid.Row="2" Grid.Column="1" Margin="0,0,5,5" VerticalAlignment="Center" 
+                    <DatePicker Text="{Binding TransContra.ChequeDate, UpdateSourceTrigger=PropertyChanged, StringFormat='{}{0:dd/MM/yyyy}'}"
+                             Grid.Row="2" Grid.Column="1" Margin="0,0,5,5" VerticalAlignment="Center"
                              HorizontalAlignment="Left" Width="120" />
                     <TextBlock Text="Cheque Amount:" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0" />
-                    <TextBox Text="{Binding TransContra.ChequeAmt, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:N2}}" 
+                    <TextBox Text="{Binding TransContra.ChequeAmt, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:N2}}"
                              Grid.Row="3" Grid.Column="1" Margin="0,0,0,5" />
                 </Grid>
-            </TabItem>
-            <TabItem Header="To Transfer">
+            </Expander>
+
+            <Expander x:Name="TransferExpander" Margin="0,0,0,5" Expanded="Expander_Expanded">
+                <Expander.Header>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="To Transfer" FontWeight="Bold" />
+                        <TextBlock Text="{Binding TransContra.TrAmount, StringFormat={}{0:C}}" Margin="10,0,0,0" />
+                    </StackPanel>
+                </Expander.Header>
                 <Grid Margin="5">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -54,7 +65,6 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
-                        <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -66,24 +76,25 @@
                     <TextBox Text="{Binding TransContra.TransferBy, UpdateSourceTrigger=PropertyChanged}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5" />
                     <TextBlock Text="Transfer Bank Code:" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0" />
                     <TextBox Text="{Binding TransContra.TrBankCode, UpdateSourceTrigger=PropertyChanged}" Grid.Row="2" Grid.Column="1" Margin="0,0,5,5" />
-                    <TextBlock Text="Transfer Amount" Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Margin="0,0,5,0" /> 
+                    <TextBlock Text="Transfer Amount" Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Margin="0,0,5,0" />
                     <TextBox Text="{Binding TransContra.TrAmount, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:N2}}" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5" />
                     <TextBlock Text="Transfer Remarks"  Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0" />
                     <TextBox Text="{Binding TransContra.TrRemarks, UpdateSourceTrigger=PropertyChanged}" Grid.Row="4" Grid.Column="1" Margin="0,0,0,5" />
-
-
-
                 </Grid>
-            </TabItem>
-            <TabItem Header="To SD">
+            </Expander>
+
+            <Expander x:Name="SdExpander" Margin="0,0,0,5" Expanded="Expander_Expanded">
+                <Expander.Header>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="To SD" FontWeight="Bold" />
+                        <TextBlock Text="{Binding TransContra.SdAmount, StringFormat={}{0:C}}" Margin="10,0,0,0" />
+                    </StackPanel>
+                </Expander.Header>
                 <Grid Margin="5">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -95,18 +106,24 @@
                     <TextBox Text="{Binding TransContra.SdAmount, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:N2}}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5" />
                     <TextBlock Text="Remarks" Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Margin="0,0,5,0" />
                     <TextBox Text="{Binding TransContra.Remarks, UpdateSourceTrigger=PropertyChanged}" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5" />
-
                 </Grid>
-            </TabItem>
-            <TabItem Header="To other heads">
-                <DataGrid ItemsSource="{Binding TransContra.PaymentDetails}" AutoGenerateColumns="False" CanUserAddRows="True" Margin="0,0,0,5">
+            </Expander>
+
+            <Expander x:Name="OtherExpander" Margin="0,0,0,5" IsExpanded="True" Expanded="Expander_Expanded">
+                <Expander.Header>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="To other heads" FontWeight="Bold" />
+                        <TextBlock Text="{Binding TransContra.OtherHeadsAmount, StringFormat={}{0:C}}" Margin="10,0,0,0" />
+                    </StackPanel>
+                </Expander.Header>
+                <DataGrid ItemsSource="{Binding TransContra.OtherTranDetails}" AutoGenerateColumns="False" CanUserAddRows="True" Margin="0,5,0,5">
                     <DataGrid.Columns>
                         <DataGridTextColumn Width="200" Header="A/C Head" Binding="{Binding AccountType, UpdateSourceTrigger=PropertyChanged}" />
                         <DataGridTextColumn Width="100" Header="Adjustment" Binding="{Binding AdjAmount, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:N2}}" />
                     </DataGrid.Columns>
                 </DataGrid>
-            </TabItem>
-        </TabControl>
+            </Expander>
+        </StackPanel>
         <TextBlock Text="Remaining:" Grid.Row="2" Grid.Column="0" Margin="0,0,5,0" VerticalAlignment="Center" />
         <TextBlock Text="{Binding RemainingAmount, StringFormat={}{0:C}}" Grid.Row="2" Grid.Column="1" VerticalAlignment="Stretch" />
     </Grid>

--- a/WpfCheckerView/Views/PaymentBalanceControl.xaml.cs
+++ b/WpfCheckerView/Views/PaymentBalanceControl.xaml.cs
@@ -1,3 +1,4 @@
+using System.Windows;
 using System.Windows.Controls;
 
 namespace WpfCheckerView.Views
@@ -7,6 +8,18 @@ namespace WpfCheckerView.Views
         public PaymentBalanceControl()
         {
             InitializeComponent();
+        }
+
+        private void Expander_Expanded(object sender, RoutedEventArgs e)
+        {
+            if (sender != ChequeExpander)
+                ChequeExpander.IsExpanded = false;
+            if (sender != TransferExpander)
+                TransferExpander.IsExpanded = false;
+            if (sender != SdExpander)
+                SdExpander.IsExpanded = false;
+            if (sender != OtherExpander)
+                OtherExpander.IsExpanded = false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Compute other-head totals from detail list
- Display "To other heads" in its own expander and collapse other sections when one expands
- Test aggregation for other-head amounts

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a84620b5008325b13378986a41dade