### PR TITLE
Add support for sub transaction details

### DIFF
--- a/WpfCheckerView.Tests/TransactionContraTests.cs
+++ b/WpfCheckerView.Tests/TransactionContraTests.cs
@@ -51,6 +51,32 @@ namespace WpfCheckerView.Tests
         }
 
         [Fact]
+        public void OtherHeadsAmount_UsesSubDetailAmounts()
+        {
+            var contra = new TransactionContra();
+            var detail = new TransactionDetail();
+            detail.MiscTranSubDetails.Add(new TransactionSubDetail { Amount = 2 });
+            detail.MiscTranSubDetails.Add(new TransactionSubDetail { Amount = 3 });
+            contra.OtherTranDetails.Add(detail);
+
+            Assert.Equal(5m, contra.OtherHeadsAmount);
+        }
+
+        [Fact]
+        public void TotalSum_IncludesSubDetailAmounts()
+        {
+            var contra = new TransactionContra
+            {
+                ChequeAmt = 10
+            };
+            var detail = new TransactionDetail();
+            detail.MiscTranSubDetails.Add(new TransactionSubDetail { Amount = 5 });
+            contra.OtherTranDetails.Add(detail);
+
+            Assert.Equal(15m, contra.TotalSum());
+        }
+
+        [Fact]
 
         public void RemainingAmount_UsesTransactionContraTotal()
         {

--- a/WpfCheckerView/Models/TransactionContra.cs
+++ b/WpfCheckerView/Models/TransactionContra.cs
@@ -25,17 +25,14 @@ namespace WpfCheckerView.Models
         public string? Remarks { get; set; }
         public ObservableCollection<TransactionDetail> OtherTranDetails { get; set; } = new();
 
-        public decimal OtherHeadsAmount => OtherTranDetails.Sum(d => (decimal)(d.AdjAmount ?? 0));
-
+        public decimal OtherHeadsAmount => OtherTranDetails.Sum(d => (decimal)d.EffectiveAdjAmount);
 
         public decimal TotalSum()
         {
-            var otherTotal = OtherTranDetails.Sum(d => (decimal)(d.AdjAmount ?? 0));
             return (decimal)((SuspenseAmt ?? 0) +
                              (ChequeAmt ?? 0) +
                              (TrAmount ?? 0) +
                              (SdAmount ?? 0)) + OtherHeadsAmount;
-
         }
     }
 }

--- a/WpfCheckerView/Models/TransactionDetail.cs
+++ b/WpfCheckerView/Models/TransactionDetail.cs
@@ -1,13 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace WpfCheckerView.Models
 {
-    public class TransactionDetail
+    public partial class TransactionDetail : INotifyPropertyChanged
     {
         public string BranchCode { get; set; }
         public string EntryFrom { get; set; }
@@ -20,8 +19,62 @@ namespace WpfCheckerView.Models
         public DateTime TranDate { get; set; }
         public int AcCode { get; set; }
         public double? CashAmount { get; set; }
-        public double? AdjAmount { get; set; }
-        public ObservableCollection<TransactionSubDetail> MiscTranSubDetails { get; set; }
-    }
 
+        private double? adjAmount;
+        public double? AdjAmount
+        {
+            get => adjAmount;
+            set
+            {
+                if (adjAmount != value)
+                {
+                    adjAmount = value;
+                    OnPropertyChanged(nameof(AdjAmount));
+                    OnPropertyChanged(nameof(EffectiveAdjAmount));
+                }
+            }
+        }
+
+        public ObservableCollection<TransactionSubDetail> MiscTranSubDetails { get; set; } = new();
+
+        public TransactionDetail()
+        {
+            MiscTranSubDetails.CollectionChanged += MiscTranSubDetails_CollectionChanged;
+        }
+
+        private void MiscTranSubDetails_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.NewItems != null)
+            {
+                foreach (TransactionSubDetail item in e.NewItems)
+                {
+                    item.PropertyChanged += SubDetail_PropertyChanged;
+                }
+            }
+            if (e.OldItems != null)
+            {
+                foreach (TransactionSubDetail item in e.OldItems)
+                {
+                    item.PropertyChanged -= SubDetail_PropertyChanged;
+                }
+            }
+            OnPropertyChanged(nameof(EffectiveAdjAmount));
+        }
+
+        private void SubDetail_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(TransactionSubDetail.Amount))
+            {
+                OnPropertyChanged(nameof(EffectiveAdjAmount));
+            }
+        }
+
+        public double EffectiveAdjAmount => MiscTranSubDetails.Any()
+            ? MiscTranSubDetails.Sum(d => d.Amount ?? 0)
+            : (AdjAmount ?? 0);
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged(string propertyName) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
 }

--- a/WpfCheckerView/Models/TransactionSubDetail.cs
+++ b/WpfCheckerView/Models/TransactionSubDetail.cs
@@ -1,20 +1,32 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.ComponentModel;
 
 namespace WpfCheckerView.Models
 {
-    public class TransactionSubDetail
+    public class TransactionSubDetail : INotifyPropertyChanged
     {
-
         public string BranchCode { get; set; }
         public string MasterId { get; set; }
         public int? RowNo { get; set; }
         public int SubCategory { get; set; }
         public long AcCode { get; set; }
         public long SubCode { get; set; }
-        public double? Amount { get; set; }
+
+        private double? amount;
+        public double? Amount
+        {
+            get => amount;
+            set
+            {
+                if (amount != value)
+                {
+                    amount = value;
+                    OnPropertyChanged(nameof(Amount));
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        protected void OnPropertyChanged(string propertyName) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }

--- a/WpfCheckerView/Views/PaymentBalanceControl.xaml
+++ b/WpfCheckerView/Views/PaymentBalanceControl.xaml
@@ -119,8 +119,25 @@
                         <TextBlock Text="{Binding TransContra.OtherHeadsAmount, StringFormat={}{0:C}}" Margin="10,0,0,0" />
                     </StackPanel>
                 </Expander.Header>
-                <DataGrid ItemsSource="{Binding TransContra.OtherTranDetails}" AutoGenerateColumns="False" CanUserAddRows="True" Margin="0,5,0,5">
+                <DataGrid ItemsSource="{Binding TransContra.OtherTranDetails}"
+                          AutoGenerateColumns="False" CanUserAddRows="True" Margin="0,5,0,5"
+                          RowDetailsVisibilityMode="Collapsed">
+                    <DataGrid.RowDetailsTemplate>
+                        <DataGrid ItemsSource="{Binding MiscTranSubDetails}" AutoGenerateColumns="False" CanUserAddRows="True">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Width="150" Header="Sub Head" Binding="{Binding SubCode, UpdateSourceTrigger=PropertyChanged}" />
+                                <DataGridTextColumn Width="100" Header="Amount" Binding="{Binding Amount, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:N2}}" />
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </DataGrid.RowDetailsTemplate>
                     <DataGrid.Columns>
+                        <DataGridTemplateColumn Width="60" Header="Subs">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Button Content="..." Click="SubHeadButton_Click" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
                         <DataGridTextColumn Width="200" Header="A/C Head" Binding="{Binding AccountType, UpdateSourceTrigger=PropertyChanged}" />
                         <DataGridTextColumn Width="100" Header="Adjustment" Binding="{Binding AdjAmount, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:N2}}" />
                     </DataGrid.Columns>

--- a/WpfCheckerView/Views/PaymentBalanceControl.xaml.cs
+++ b/WpfCheckerView/Views/PaymentBalanceControl.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 
 namespace WpfCheckerView.Views
 {
@@ -20,6 +21,31 @@ namespace WpfCheckerView.Views
                 SdExpander.IsExpanded = false;
             if (sender != OtherExpander)
                 OtherExpander.IsExpanded = false;
+        }
+
+        private void SubHeadButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button button)
+            {
+                var row = FindAncestor<DataGridRow>(button);
+                if (row != null)
+                {
+                    row.DetailsVisibility = row.DetailsVisibility == Visibility.Visible
+                        ? Visibility.Collapsed
+                        : Visibility.Visible;
+                }
+            }
+        }
+
+        private static T? FindAncestor<T>(DependencyObject current) where T : DependencyObject
+        {
+            while (current != null)
+            {
+                if (current is T target)
+                    return target;
+                current = VisualTreeHelper.GetParent(current);
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Allow other-head entries to expand sub transactions in PaymentBalance view
- Calculate effective adjustments from sub detail amounts
- Ensure totals include sub transaction details with tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a856d7cebc8325ac00ef142c909487