### PR TITLE
Left-align amounts and toggle subhead grid

### DIFF
--- a/WpfCheckerView/Views/PaymentBalanceControl.xaml
+++ b/WpfCheckerView/Views/PaymentBalanceControl.xaml
@@ -27,22 +27,21 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="150" SharedSizeGroup="CurrencyValue" />
+                    <ColumnDefinition Width="10" />
+                    <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
                 <Expander x:Name="ChequeExpander" Margin="0,0,0,5" Grid.Row="0" Grid.ColumnSpan="3" Expanded="Expander_Expanded">
 
                     <Expander.Header  >
                         <Grid>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="10" />
                                 <ColumnDefinition Width="150" SharedSizeGroup="CurrencyValue" />
+                                <ColumnDefinition Width="10" />
+                                <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <TextBlock Text="To Cheque" FontWeight="Bold"  Grid.Column="0"/>
-                            <TextBlock Text="{Binding TransContra.ChequeAmt, StringFormat={}{0:C}}" Grid.Column="3" />
+                            <TextBlock Text="{Binding TransContra.ChequeAmt, StringFormat={}{0:C}}" Grid.Column="0" />
+                            <TextBlock Text="To Cheque" FontWeight="Bold"  Grid.Column="2"/>
                         </Grid>
                 </Expander.Header>
                 <Grid Margin="5">
@@ -75,14 +74,13 @@
                 <Expander.Header>
                         <Grid>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="10" />
                                 <ColumnDefinition Width="150" SharedSizeGroup="CurrencyValue" />
+                                <ColumnDefinition Width="10" />
+                                <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <TextBlock Text="To Transfer" FontWeight="Bold"  Grid.Column="0"/>
-                            <TextBlock Text="{Binding TransContra.TrAmount, StringFormat={}{0:C}}" Grid.Column="3" />
-                        </Grid>                        
+                            <TextBlock Text="{Binding TransContra.TrAmount, StringFormat={}{0:C}}" Grid.Column="0" />
+                            <TextBlock Text="To Transfer" FontWeight="Bold"  Grid.Column="2"/>
+                        </Grid>
                 </Expander.Header>
                 <Grid Margin="5">
                     <Grid.RowDefinitions>
@@ -114,13 +112,12 @@
                 <Expander.Header>
                         <Grid>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="10" />
                                 <ColumnDefinition Width="150" SharedSizeGroup="CurrencyValue" />
+                                <ColumnDefinition Width="10" />
+                                <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <TextBlock Text="To SD" FontWeight="Bold"  Grid.Column="0"/>
-                            <TextBlock Text="{Binding TransContra.SdAmount, StringFormat={}{0:C}}" Grid.Column="3" />
+                            <TextBlock Text="{Binding TransContra.SdAmount, StringFormat={}{0:C}}" Grid.Column="0" />
+                            <TextBlock Text="To SD" FontWeight="Bold"  Grid.Column="2"/>
                         </Grid>
                 </Expander.Header>
                 <Grid Margin="5">
@@ -146,13 +143,12 @@
                 <Expander.Header >
                         <Grid>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="10" />
                                 <ColumnDefinition Width="150" SharedSizeGroup="CurrencyValue" />
+                                <ColumnDefinition Width="10" />
+                                <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <TextBlock Text="To  other heads" FontWeight="Bold"  Grid.Column="0"/>
-                            <TextBlock Text="{Binding TransContra.OtherHeadsAmount, StringFormat={}{0:C}}" Grid.Column="3" />
+                            <TextBlock Text="{Binding TransContra.OtherHeadsAmount, StringFormat={}{0:C}}" Grid.Column="0" />
+                            <TextBlock Text="To  other heads" FontWeight="Bold"  Grid.Column="2"/>
                         </Grid>
                 </Expander.Header>
                 <Grid Margin="0,5,0,5">
@@ -172,7 +168,18 @@
                                 <DataGridTemplateColumn Width="60" Header="Subs">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
-                                            <Button Content="..." Click="SubHeadButton_Click" />
+                                            <ToggleButton Content="..." Checked="SubHeadToggle_Checked" Unchecked="SubHeadToggle_Unchecked">
+                                                <ToggleButton.Style>
+                                                    <Style TargetType="ToggleButton">
+                                                        <Style.Triggers>
+                                                            <Trigger Property="IsChecked" Value="True">
+                                                                <Setter Property="Background" Value="Blue" />
+                                                                <Setter Property="Foreground" Value="White" />
+                                                            </Trigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </ToggleButton.Style>
+                                            </ToggleButton>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>

--- a/WpfCheckerView/Views/PaymentBalanceControl.xaml.cs
+++ b/WpfCheckerView/Views/PaymentBalanceControl.xaml.cs
@@ -1,6 +1,8 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Media;
+using WpfCheckerView.Models;
 
 namespace WpfCheckerView.Views
 {
@@ -23,17 +25,30 @@ namespace WpfCheckerView.Views
                 OtherExpander.IsExpanded = false;
         }
 
-        private void SubHeadButton_Click(object sender, RoutedEventArgs e)
+        private void SubHeadToggle_Checked(object sender, RoutedEventArgs e)
         {
-            if (sender is Button button)
+            if (sender is ToggleButton toggle)
             {
-                var row = FindAncestor<DataGridRow>(button);
+                var row = FindAncestor<DataGridRow>(toggle);
                 if (row != null)
                 {
                     row.IsSelected = true;
-                    SubDetailsExpander.IsExpanded = !SubDetailsExpander.IsExpanded;
+                    SubDetailsExpander.IsExpanded = true;
                 }
             }
+        }
+
+        private void SubHeadToggle_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (sender is ToggleButton toggle)
+            {
+                var row = FindAncestor<DataGridRow>(toggle);
+                if (row?.DataContext is TransactionDetail detail)
+                {
+                    detail.MiscTranSubDetails.Clear();
+                }
+            }
+            SubDetailsExpander.IsExpanded = false;
         }
 
         private static T? FindAncestor<T>(DependencyObject current) where T : DependencyObject


### PR DESCRIPTION
## Summary
- show amounts on left side for all payment expanders
- make other-heads subhead button a blue toggle that clears subheads when turned off

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a897eaf31c8325957b3507faab6c99