### PR TITLE
Auto-update RemainingAmount when payments change

### DIFF
--- a/WpfCheckerView.Tests/PaymentBalanceViewModelTests.cs
+++ b/WpfCheckerView.Tests/PaymentBalanceViewModelTests.cs
@@ -25,6 +25,24 @@ namespace WpfCheckerView.Tests
 
             Assert.True(raised);
         }
+
+        [Fact]
+        public void RemainingAmount_NotifiesOnTransactionChange()
+        {
+            var vm = new PaymentBalanceViewModel { TotalAmount = 100m };
+            bool raised = false;
+            vm.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(PaymentBalanceViewModel.RemainingAmount))
+                {
+                    raised = true;
+                }
+            };
+
+            vm.TransContra.ChequeAmt = 40;
+
+            Assert.True(raised);
+        }
         //[Fact]
         //public void RemainingAmountUpdatesWithPayments()
         //{

--- a/WpfCheckerView/Models/TransactionContra.cs
+++ b/WpfCheckerView/Models/TransactionContra.cs
@@ -1,29 +1,73 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace WpfCheckerView.Models
 {
-    public class TransactionContra
+    public partial class TransactionContra : ObservableObject
     {
         public double? TotalAdjustment { get; set; }
         public long? AcCode { get; set; }
         public string EmployeeId { get; set; }
-        public double? SuspenseAmt { get; set; }
+
+        [ObservableProperty]
+        private double? suspenseAmt;
+
         public long? BankFasCode { get; set; }
         public string? ChequeNo { get; set; }
-        public double? ChequeAmt { get; set; }
+
+        [ObservableProperty]
+        private double? chequeAmt;
+
         public string? TransferBy { get; set; }
         public int? TrBankCode { get; set; }
-        public double? TrAmount { get; set; }
+
+        [ObservableProperty]
+        private double? trAmount;
+
         public string? TrRemarks { get; set; }
         public string? SdAccountId { get; set; }
-        public double? SdAmount { get; set; }
+
+        [ObservableProperty]
+        private double? sdAmount;
+
         public string? Remarks { get; set; }
-        public ObservableCollection<TransactionDetail> OtherTranDetails { get; set; } = new();
+
+        public ObservableCollection<TransactionDetail> OtherTranDetails { get; } = new();
+
+        public TransactionContra()
+        {
+            OtherTranDetails.CollectionChanged += OtherTranDetails_CollectionChanged;
+        }
+
+        private void OtherTranDetails_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.NewItems != null)
+            {
+                foreach (TransactionDetail item in e.NewItems)
+                {
+                    item.PropertyChanged += Detail_PropertyChanged;
+                }
+            }
+            if (e.OldItems != null)
+            {
+                foreach (TransactionDetail item in e.OldItems)
+                {
+                    item.PropertyChanged -= Detail_PropertyChanged;
+                }
+            }
+            OnPropertyChanged(nameof(OtherHeadsAmount));
+        }
+
+        private void Detail_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(TransactionDetail.EffectiveAdjAmount))
+            {
+                OnPropertyChanged(nameof(OtherHeadsAmount));
+            }
+        }
 
         public decimal OtherHeadsAmount => OtherTranDetails.Sum(d => (decimal)d.EffectiveAdjAmount);
 
@@ -36,3 +80,4 @@ namespace WpfCheckerView.Models
         }
     }
 }
+

--- a/WpfCheckerView/ViewModels/PaymentBalanceViewModel.cs
+++ b/WpfCheckerView/ViewModels/PaymentBalanceViewModel.cs
@@ -1,6 +1,4 @@
-using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WpfCheckerView.Models;
@@ -25,7 +23,35 @@ namespace WpfCheckerView.ViewModels
 
         public PaymentBalanceViewModel()
         {
-            //  PaymentMethods.CollectionChanged += PaymentMethods_CollectionChanged;
+            TransContra.PropertyChanged += TransContra_PropertyChanged;
+        }
+
+        partial void OnTransContraChanging(TransactionContra value)
+        {
+            if (value != null)
+            {
+                value.PropertyChanged -= TransContra_PropertyChanged;
+            }
+        }
+
+        partial void OnTransContraChanged(TransactionContra value)
+        {
+            if (value != null)
+            {
+                value.PropertyChanged += TransContra_PropertyChanged;
+            }
+        }
+
+        private void TransContra_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(TransactionContra.SuspenseAmt) ||
+                e.PropertyName == nameof(TransactionContra.ChequeAmt) ||
+                e.PropertyName == nameof(TransactionContra.TrAmount) ||
+                e.PropertyName == nameof(TransactionContra.SdAmount) ||
+                e.PropertyName == nameof(TransactionContra.OtherHeadsAmount))
+            {
+                OnPropertyChanged(nameof(RemainingAmount));
+            }
         }
 
         //private void PaymentMethods_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
## Summary
- make TransactionContra observable and notify when component amounts or detail entries change
- propagate TransactionContra changes to PaymentBalanceViewModel so RemainingAmount updates automatically
- test that RemainingAmount raises change notifications when payment values adjust

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8988a3b7883258e78562cb44dd74b