### PR TITLE
Use Syncfusion grid and expander in payment balance UI

### DIFF
--- a/WpfCheckerView/Views/PaymentBalanceControl.xaml
+++ b/WpfCheckerView/Views/PaymentBalanceControl.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
              mc:Ignorable="d" MinHeight="230" Background="AliceBlue">
     <Grid Margin="5">
         <Grid.RowDefinitions>
@@ -31,8 +32,8 @@
                     <ColumnDefinition Width="10" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-                <Expander x:Name="ChequeExpander" Margin="0,0,0,5" Grid.Row="0" Grid.ColumnSpan="3" Expanded="Expander_Expanded">
-                    <Expander.Header>
+                <syncfusion:SfExpander x:Name="ChequeExpander" Margin="0,0,0,5" Grid.Row="0" Grid.ColumnSpan="3" Expanded="Expander_Expanded">
+                    <syncfusion:SfExpander.Header>
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" SharedSizeGroup="ExpanderHederLable"/>
@@ -42,7 +43,7 @@
                             <TextBlock Text="To Cheque" FontWeight="Bold" Grid.Column="0" />
                             <TextBlock Text="{Binding TransContra.ChequeAmt, StringFormat={}{0:C}}" Grid.Column="2" HorizontalAlignment="Right" />
                         </Grid>
-                    </Expander.Header>
+                    </syncfusion:SfExpander.Header>
                 <Grid Margin="5">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -66,10 +67,10 @@
                     <TextBox Text="{Binding TransContra.ChequeAmt, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:N2}}"
                              Grid.Row="3" Grid.Column="1" Margin="0,0,0,5" />
                 </Grid>
-            </Expander>
+            </syncfusion:SfExpander>
 
-                <Expander x:Name="TransferExpander" Margin="0,0,0,5"  Grid.Row="1" Grid.ColumnSpan="3" Expanded="Expander_Expanded">
-                    <Expander.Header>
+                <syncfusion:SfExpander x:Name="TransferExpander" Margin="0,0,0,5"  Grid.Row="1" Grid.ColumnSpan="3" Expanded="Expander_Expanded">
+                    <syncfusion:SfExpander.Header>
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" SharedSizeGroup="ExpanderHederLable"/>
@@ -79,7 +80,7 @@
                             <TextBlock Text="To Transfer" FontWeight="Bold" Grid.Column="0" />
                             <TextBlock Text="{Binding TransContra.TrAmount, StringFormat={}{0:C}}" Grid.Column="2" HorizontalAlignment="Right" />
                         </Grid>
-                    </Expander.Header>
+                    </syncfusion:SfExpander.Header>
                 <Grid Margin="5">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -103,10 +104,10 @@
                     <TextBlock Text="Transfer Remarks"  Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,5,0" />
                     <TextBox Text="{Binding TransContra.TrRemarks, UpdateSourceTrigger=PropertyChanged}" Grid.Row="4" Grid.Column="1" Margin="0,0,0,5" />
                 </Grid>
-            </Expander>
+            </syncfusion:SfExpander>
 
-                <Expander x:Name="SdExpander" Margin="0,0,0,5"  Grid.Row="2" Grid.ColumnSpan="3" Expanded="Expander_Expanded">
-                    <Expander.Header>
+                <syncfusion:SfExpander x:Name="SdExpander" Margin="0,0,0,5"  Grid.Row="2" Grid.ColumnSpan="3" Expanded="Expander_Expanded">
+                    <syncfusion:SfExpander.Header>
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" SharedSizeGroup="ExpanderHederLable"/>
@@ -116,7 +117,7 @@
                             <TextBlock Text="To SD" FontWeight="Bold" Grid.Column="0" />
                             <TextBlock Text="{Binding TransContra.SdAmount, StringFormat={}{0:C}}" Grid.Column="2" HorizontalAlignment="Right" />
                         </Grid>
-                    </Expander.Header>
+                    </syncfusion:SfExpander.Header>
                 <Grid Margin="5">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -134,10 +135,10 @@
                     <TextBlock Text="Remarks" Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Margin="0,0,5,0" />
                     <TextBox Text="{Binding TransContra.Remarks, UpdateSourceTrigger=PropertyChanged}" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5" />
                 </Grid>
-            </Expander>
+            </syncfusion:SfExpander>
 
-                <Expander x:Name="OtherExpander" Margin="0,0,0,5"  Grid.Row="3" Grid.ColumnSpan="3" IsExpanded="True" Expanded="Expander_Expanded">
-                    <Expander.Header>
+                <syncfusion:SfExpander x:Name="OtherExpander" Margin="0,0,0,5"  Grid.Row="3" Grid.ColumnSpan="3" IsExpanded="True" Expanded="Expander_Expanded">
+                    <syncfusion:SfExpander.Header>
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" SharedSizeGroup="ExpanderHederLable" />
@@ -147,23 +148,23 @@
                             <TextBlock Text="To Other Heads" FontWeight="Bold" Grid.Column="0" />
                             <TextBlock Text="{Binding TransContra.OtherHeadsAmount, StringFormat={}{0:C}}" Grid.Column="2" HorizontalAlignment="Right" />
                         </Grid>
-                    </Expander.Header>
+                    </syncfusion:SfExpander.Header>
                 <Grid Margin="0,5,0,5">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*" />
                             <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
-                    <DataGrid x:Name="OtherHeadsDataGrid"
+                    <syncfusion:SfDataGrid x:Name="OtherHeadsDataGrid"
                               ItemsSource="{Binding TransContra.OtherTranDetails}"
-                              AutoGenerateColumns="False" CanUserAddRows="True"
+                              AutoGenerateColumns="False" AddNewRowPosition="Top"
                               SelectedItem="{Binding SelectedOtherTranDetail}">
-                        <DataGrid.Columns>
+                        <syncfusion:SfDataGrid.Columns>
 
-                            <DataGridTextColumn Width="250" Header="A/C Head" Binding="{Binding AccountType, UpdateSourceTrigger=PropertyChanged}" />
-                            <DataGridTextColumn Width="100" Header="Adjustment" Binding="{Binding AdjAmount, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:N2}}" />
-                                <DataGridTemplateColumn Width="60" Header="Subs">
-                                    <DataGridTemplateColumn.CellTemplate>
+                            <syncfusion:GridTextColumn Width="250" HeaderText="A/C Head" MappingName="AccountType" />
+                            <syncfusion:GridTextColumn Width="100" HeaderText="Adjustment" MappingName="AdjAmount" />
+                                <syncfusion:GridTemplateColumn Width="60" HeaderText="Subs">
+                                    <syncfusion:GridTemplateColumn.CellTemplate>
                                         <DataTemplate>
                                             <ToggleButton Content="..." Checked="SubHeadToggle_Checked" Unchecked="SubHeadToggle_Unchecked">
                                                 <ToggleButton.Style>
@@ -188,13 +189,13 @@
                                                 </ToggleButton.Style>
                                             </ToggleButton>
                                         </DataTemplate>
-                                    </DataGridTemplateColumn.CellTemplate>
-                                </DataGridTemplateColumn>
-                            </DataGrid.Columns>
-                    </DataGrid>
+                                    </syncfusion:GridTemplateColumn.CellTemplate>
+                                </syncfusion:GridTemplateColumn>
+                            </syncfusion:SfDataGrid.Columns>
+                    </syncfusion:SfDataGrid>
 
-                        <Expander x:Name="SubDetailsExpander" Grid.Row="1" Grid.ColumnSpan="3" Margin="5,0,0,0" IsExpanded="False">
-                        <Expander.Header>
+                        <syncfusion:SfExpander x:Name="SubDetailsExpander" Grid.Row="1" Grid.ColumnSpan="3" Margin="5,0,0,0" IsExpanded="False">
+                        <syncfusion:SfExpander.Header>
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" SharedSizeGroup="ExpanderHederLable" />
@@ -204,9 +205,9 @@
                                 <TextBlock Text="Sub Details" FontWeight="Bold" Grid.Column="0" />
                                 <TextBlock Text="{Binding SelectedItem.SubDetailsTotal, ElementName=OtherHeadsDataGrid, StringFormat={}{0:C}}" Grid.Column="2" HorizontalAlignment="Right" />
                             </Grid>
-                        </Expander.Header>
-                        <Expander.Style>
-                            <Style TargetType="Expander">
+                        </syncfusion:SfExpander.Header>
+                        <syncfusion:SfExpander.Style>
+                            <Style TargetType="syncfusion:SfExpander">
                                 <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding SelectedItem, ElementName=OtherHeadsDataGrid}" Value="{x:Null}">
@@ -214,17 +215,17 @@
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
-                        </Expander.Style>
-                        <DataGrid ItemsSource="{Binding SelectedItem.MiscTranSubDetails, ElementName=OtherHeadsDataGrid}"
-                                  AutoGenerateColumns="False" CanUserAddRows="True" Height="80">
-                            <DataGrid.Columns>
-                                    <DataGridTextColumn Width="250" Header="Sub Head" Binding="{Binding SubCode, UpdateSourceTrigger=PropertyChanged}" />
-                                <DataGridTextColumn Width="100" Header="Amount" Binding="{Binding Amount, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:N2}}" />
-                            </DataGrid.Columns>
-                        </DataGrid>
-                    </Expander>
+                        </syncfusion:SfExpander.Style>
+                        <syncfusion:SfDataGrid ItemsSource="{Binding SelectedItem.MiscTranSubDetails, ElementName=OtherHeadsDataGrid}"
+                                  AutoGenerateColumns="False" AddNewRowPosition="Top" Height="80">
+                            <syncfusion:SfDataGrid.Columns>
+                                    <syncfusion:GridTextColumn Width="250" HeaderText="Sub Head" MappingName="SubCode" />
+                                <syncfusion:GridTextColumn Width="100" HeaderText="Amount" MappingName="Amount" />
+                            </syncfusion:SfDataGrid.Columns>
+                        </syncfusion:SfDataGrid>
+                    </syncfusion:SfExpander>
                 </Grid>
-            </Expander>
+            </syncfusion:SfExpander>
         </Grid>
         </Border>
         <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal">

--- a/WpfCheckerView/Views/PaymentBalanceControl.xaml.cs
+++ b/WpfCheckerView/Views/PaymentBalanceControl.xaml.cs
@@ -1,7 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using System.Windows.Media;
 using WpfCheckerView.Models;
 
 namespace WpfCheckerView.Views
@@ -27,39 +26,20 @@ namespace WpfCheckerView.Views
 
         private void SubHeadToggle_Checked(object sender, RoutedEventArgs e)
         {
-            if (sender is ToggleButton toggle)
+            if (sender is ToggleButton toggle && toggle.DataContext is TransactionDetail detail)
             {
-                var row = FindAncestor<DataGridRow>(toggle);
-                if (row != null)
-                {
-                    row.IsSelected = true;
-                    SubDetailsExpander.IsExpanded = true;
-                }
+                OtherHeadsDataGrid.SelectedItem = detail;
+                SubDetailsExpander.IsExpanded = true;
             }
         }
 
         private void SubHeadToggle_Unchecked(object sender, RoutedEventArgs e)
         {
-            if (sender is ToggleButton toggle)
+            if (sender is ToggleButton toggle && toggle.DataContext is TransactionDetail detail)
             {
-                var row = FindAncestor<DataGridRow>(toggle);
-                if (row?.DataContext is TransactionDetail detail)
-                {
-                    detail.MiscTranSubDetails.Clear();
-                }
+                detail.MiscTranSubDetails.Clear();
             }
             SubDetailsExpander.IsExpanded = false;
-        }
-
-        private static T? FindAncestor<T>(DependencyObject current) where T : DependencyObject
-        {
-            while (current != null)
-            {
-                if (current is T target)
-                    return target;
-                current = VisualTreeHelper.GetParent(current);
-            }
-            return null;
         }
     }
 }

--- a/WpfCheckerView/WpfCheckerView.csproj
+++ b/WpfCheckerView/WpfCheckerView.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Syncfusion.SfGrid.WPF" Version="29.1.41" />
+    <PackageReference Include="Syncfusion.SfExpander.WPF" Version="29.1.41" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Replace WPF Expanders with Syncfusion SfExpander controls
- Swap DataGrids for Syncfusion SfDataGrid in PaymentBalanceControl
- Adjust toggle logic to select rows without relying on DataGridRow
- Reference Syncfusion SfExpander package

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a8af09eb0083258afa4dd5eeb94d39