### PR TITLE
Add theme switching for Syncfusion WPF app

### DIFF
--- a/WpfCheckerView/ViewModels/MainViewModel.cs
+++ b/WpfCheckerView/ViewModels/MainViewModel.cs
@@ -3,6 +3,8 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WpfCheckerView.Models;
 using WpfCheckerView.Services;
+using Syncfusion.SfSkinManager;
+using System.Windows;
 
 namespace WpfCheckerView.ViewModels
 {
@@ -38,12 +40,36 @@ namespace WpfCheckerView.ViewModels
         [ObservableProperty]
         private PaymentBalanceViewModel paymentBalance = new();
 
+        [ObservableProperty]
+        private ObservableCollection<string> themes = null!;
+
+        [ObservableProperty]
+        private string selectedTheme = string.Empty;
+
         public MainViewModel(IEmployeeService employeeService, IDepartmentService departmentService)
         {
             _employeeService = employeeService;
             _departmentService = departmentService;
             PaymentBalance.TotalAmount = 100m;
             LoadData();
+
+            Themes = new ObservableCollection<string>
+            {
+                "FluentLight",
+                "FluentDark",
+                "MaterialLight",
+                "Material3Dark",
+                "Metro",
+                "Office2010Blue",
+                "Office365",
+                "Lime",
+                "Saffron",
+                "SystemTheme",
+                "Windows11Dark",
+                "Windows11Light"
+            };
+
+            SelectedTheme = "FluentLight";
         }
 
         private void LoadData()
@@ -94,6 +120,16 @@ namespace WpfCheckerView.ViewModels
             NewEmployeeSalary = string.Empty;
             NewEmployeeIdProof = string.Empty;
             NewEmployeePanNo = string.Empty;
+        }
+
+        [RelayCommand]
+        private void ApplyTheme()
+        {
+            if (Application.Current.MainWindow is not null)
+            {
+                SfSkinManager.SetTheme(Application.Current.MainWindow,
+                    new Theme() { ThemeName = SelectedTheme });
+            }
         }
     }
 }

--- a/WpfCheckerView/Views/MainWindow.xaml
+++ b/WpfCheckerView/Views/MainWindow.xaml
@@ -11,10 +11,20 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <Grid Margin="10" Grid.Row="0">
+        <StackPanel Orientation="Horizontal" Margin="10" Grid.Row="0">
+            <TextBlock Text="Theme:" VerticalAlignment="Center" Margin="0,0,5,0" />
+            <ComboBox Width="150" Margin="0,0,5,0"
+                      ItemsSource="{Binding Themes}"
+                      SelectedItem="{Binding SelectedTheme}" />
+            <Button Content="Apply" Width="80"
+                    Command="{Binding ApplyThemeCommand}" />
+        </StackPanel>
+
+        <Grid Margin="10" Grid.Row="1">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -56,7 +66,7 @@
                     Command="{Binding AddNewEmployeeCommand}" Grid.Row="6" Grid.Column="1" />
         </Grid>
 
-        <Grid Grid.Row="1">
+        <Grid Grid.Row="2">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />

--- a/WpfCheckerView/Views/MainWindow.xaml.cs
+++ b/WpfCheckerView/Views/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using WpfCheckerView.ViewModels;
 using WpfCheckerView.Services;
+using Syncfusion.SfSkinManager;
 
 namespace WpfCheckerView.Views
 {
@@ -12,6 +13,8 @@ namespace WpfCheckerView.Views
         public MainWindow()
         {
             InitializeComponent();
+            SfSkinManager.ApplyStylesOnApplication = true;
+            SfSkinManager.SetTheme(this, new Theme() { ThemeName = "FluentLight" });
             var dataService = new MockDataService();
             DataContext = new MainViewModel(dataService, dataService);
         }


### PR DESCRIPTION
## Summary
- default to FluentLight Syncfusion theme
- allow selecting from all installed themes and applying them

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bee071a08325821cd5c78f74e219