### PR TITLE
Run system configuration check on startup

### DIFF
--- a/SystemConfigChecker/Program.cs
+++ b/SystemConfigChecker/Program.cs
@@ -9,11 +9,11 @@ using System.Text.RegularExpressions;
 
 namespace SystemConfigChecker;
 
-internal static class Program
+public static class Program
 {
     private static readonly string LogFile = Path.Combine(AppContext.BaseDirectory, "system_config.log");
 
-    private static void Main()
+    public static void Main()
     {
         try
         {

--- a/WpfCheckerView/App.xaml.cs
+++ b/WpfCheckerView/App.xaml.cs
@@ -1,7 +1,7 @@
 ﻿using System.Configuration;
 using System.Data;
 using System.Windows;
-
+using SystemConfigChecker;
 
 namespace WpfCheckerView
 {
@@ -13,6 +13,7 @@ namespace WpfCheckerView
 
         protected override void OnStartup(StartupEventArgs e)
         {
+            base.OnStartup(e);
             try
             {
                 //Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("Ngo9BigBOggjHTQxAR8/V1NHaF5cXmVCf1FpRmJGdld5fUVHYVZUTXxaS00DNHVRdkdgWXZfd3RSRGhZVkxxVko="); 23.1.36
@@ -25,6 +26,8 @@ namespace WpfCheckerView
             {
                 MessageBox.Show($"Error registering Syncfusion license: {ex.Message}", "License Error", MessageBoxButton.OK, MessageBoxImage.Error);
             }
+
+            Program.Main();
         }
     }
 

--- a/WpfCheckerView/WpfCheckerView.csproj
+++ b/WpfCheckerView/WpfCheckerView.csproj
@@ -34,8 +34,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CustomControls\CustomControls.csproj" />
+    <ProjectReference Include="..\SystemConfigChecker\SystemConfigChecker.csproj" />
   </ItemGroup>
-	<ItemGroup>
-		<Resource Include="AppIcon.ico" />
-	</ItemGroup>
+  <ItemGroup>
+    <Resource Include="AppIcon.ico" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Exposed SystemConfigChecker entry point and invoked it when the WPF app starts to log system configuration details.
- Added reference from the UI project to SystemConfigChecker so the startup logic can invoke the checker.

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2db586624832585bdbecf7d77d663