### PR TITLE
Add demo for conditional details grid

### DIFF
--- a/WpfCheckerView/Models/FasHeadModels.cs
+++ b/WpfCheckerView/Models/FasHeadModels.cs
@@ -1,0 +1,23 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace WpfCheckerView.Models;
+
+public class FasHead
+{
+    public long FasCode { get; set; }
+    public string FasName { get; set; } = string.Empty;
+    public int CategoryCode { get; set; }
+    public string CategoryHead { get; set; } = string.Empty;
+    public double AdjAmount { get; set; }
+    public ObservableCollection<FasHeadSubCategory> SubHeads { get; } = new();
+    public bool HasSubHeads => SubHeads.Any();
+}
+
+public class FasHeadSubCategory
+{
+    public long SubCode { get; set; }
+    public string SubName { get; set; } = string.Empty;
+    public double Amount { get; set; }
+}
+

--- a/WpfCheckerView/ViewModels/FasHeadDemoViewModel.cs
+++ b/WpfCheckerView/ViewModels/FasHeadDemoViewModel.cs
@@ -1,0 +1,42 @@
+using System.Collections.ObjectModel;
+using WpfCheckerView.Models;
+
+namespace WpfCheckerView.ViewModels;
+
+public class FasHeadDemoViewModel
+{
+    public ObservableCollection<FasHead> FasHeads { get; } = new();
+
+    public FasHeadDemoViewModel()
+    {
+        FasHeads.Add(new FasHead
+        {
+            FasCode = 1,
+            FasName = "Share Capital A Class",
+            CategoryCode = 1,
+            CategoryHead = "Agent Name",
+            AdjAmount = 1000
+        });
+
+        var loanHead = new FasHead
+        {
+            FasCode = 2,
+            FasName = "Loan to Members Ordinary",
+            CategoryCode = 2,
+            CategoryHead = "Agent Name"
+        };
+        loanHead.SubHeads.Add(new FasHeadSubCategory { SubCode = 201, SubName = "Member A", Amount = 300 });
+        loanHead.SubHeads.Add(new FasHeadSubCategory { SubCode = 202, SubName = "Member B", Amount = 200 });
+        FasHeads.Add(loanHead);
+
+        FasHeads.Add(new FasHead
+        {
+            FasCode = 3,
+            FasName = "Interest on Loans Ordinary",
+            CategoryCode = 2,
+            CategoryHead = "Due-by Head",
+            AdjAmount = 150
+        });
+    }
+}
+

--- a/WpfCheckerView/Views/FasHeadDemoControl.xaml
+++ b/WpfCheckerView/Views/FasHeadDemoControl.xaml
@@ -1,0 +1,52 @@
+<UserControl x:Class="WpfCheckerView.Views.FasHeadDemoControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             xmlns:vm="clr-namespace:WpfCheckerView.ViewModels"
+             MinHeight="230">
+    <UserControl.DataContext>
+        <vm:FasHeadDemoViewModel/>
+    </UserControl.DataContext>
+    <UserControl.Resources>
+        <sys:Double x:Key="ExpanderHeaderWidth">300</sys:Double>
+        <sys:Double x:Key="AmountHeaderWidth">100</sys:Double>
+    </UserControl.Resources>
+    <Grid>
+        <syncfusion:SfDataGrid x:Name="FasGrid"
+                               ItemsSource="{Binding FasHeads}"
+                               AutoGenerateColumns="False"
+                               ShowRowHeader="False"
+                               NavigationMode="Cell">
+            <syncfusion:SfDataGrid.Columns>
+                <syncfusion:GridTextColumn MappingName="FasName" HeaderText="A/C Head" Width="{StaticResource ExpanderHeaderWidth}"/>
+                <syncfusion:GridNumericColumn MappingName="AdjAmount" HeaderText="Adjustment" Width="{StaticResource AmountHeaderWidth}"/>
+            </syncfusion:SfDataGrid.Columns>
+            <syncfusion:SfDataGrid.RowExpanderStyle>
+                <Style TargetType="syncfusion:GridRowExpanderCell">
+                    <Setter Property="Visibility" Value="Visible"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Record.HasSubHeads}" Value="False">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </syncfusion:SfDataGrid.RowExpanderStyle>
+            <syncfusion:SfDataGrid.DetailsViewDefinition>
+                <syncfusion:GridViewDefinition>
+                    <syncfusion:GridViewDefinition.RelationalColumn>SubHeads</syncfusion:GridViewDefinition.RelationalColumn>
+                    <syncfusion:GridViewDefinition.DataGrid>
+                        <syncfusion:SfDataGrid AutoGenerateColumns="False"
+                                               ShowRowHeader="False"
+                                               NavigationMode="Cell">
+                            <syncfusion:SfDataGrid.Columns>
+                                <syncfusion:GridTextColumn MappingName="SubName" HeaderText="Sub Head" Width="{StaticResource ExpanderHeaderWidth}"/>
+                                <syncfusion:GridNumericColumn MappingName="Amount" HeaderText="Amount" Width="{StaticResource AmountHeaderWidth}"/>
+                            </syncfusion:SfDataGrid.Columns>
+                        </syncfusion:SfDataGrid>
+                    </syncfusion:GridViewDefinition.DataGrid>
+                </syncfusion:GridViewDefinition>
+            </syncfusion:SfDataGrid.DetailsViewDefinition>
+        </syncfusion:SfDataGrid>
+    </Grid>
+</UserControl>

--- a/WpfCheckerView/Views/FasHeadDemoControl.xaml.cs
+++ b/WpfCheckerView/Views/FasHeadDemoControl.xaml.cs
@@ -1,0 +1,24 @@
+using System.Windows.Controls;
+using Syncfusion.UI.Xaml.Grid;
+using WpfCheckerView.Models;
+using WpfCheckerView.ViewModels;
+
+namespace WpfCheckerView.Views;
+
+public partial class FasHeadDemoControl : UserControl
+{
+    public FasHeadDemoControl()
+    {
+        InitializeComponent();
+        FasGrid.DetailsViewManager.QueryDetailsViewExpanding += DetailsViewManager_QueryDetailsViewExpanding;
+    }
+
+    private void DetailsViewManager_QueryDetailsViewExpanding(object? sender, QueryDetailsViewExpandingEventArgs e)
+    {
+        if (e.Record is FasHead head && !head.HasSubHeads)
+        {
+            e.Cancel = true;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add FasHead and FasHeadSubCategory models with HasSubHeads helper
- Provide dummy FasHeadDemoViewModel populating sample data with and without subheads
- Introduce FasHeadDemoControl demonstrating Syncfusion SfDataGrid with conditional details view

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6dec9e2108325acaa13f700f29927