### PR TITLE
Bind FasGrid to transaction detail collections

### DIFF
--- a/WpfCheckerView/Models/FasHeadModels.cs
+++ b/WpfCheckerView/Models/FasHeadModels.cs
@@ -1,6 +1,3 @@
-using System.Collections.ObjectModel;
-using System.Linq;
-
 namespace WpfCheckerView.Models;
 
 public class FasHead
@@ -9,15 +6,13 @@ public class FasHead
     public string FasName { get; set; } = string.Empty;
     public int CategoryCode { get; set; }
     public string CategoryHead { get; set; } = string.Empty;
-    public double AdjAmount { get; set; }
-    public ObservableCollection<FasHeadSubCategory> SubHeads { get; } = new();
-    public bool HasSubHeads => SubHeads.Any();
 }
 
-public class FasHeadSubCategory
+public class FasHeadSubCategories
 {
     public long SubCode { get; set; }
     public string SubName { get; set; } = string.Empty;
-    public double Amount { get; set; }
+    public string SelectedBranch { get; set; } = string.Empty;
+    public int CategoryCode { get; set; }
+    public string CategoryHead { get; set; } = string.Empty;
 }
-

--- a/WpfCheckerView/Models/TransactionDetail.cs
+++ b/WpfCheckerView/Models/TransactionDetail.cs
@@ -34,6 +34,10 @@ public partial class TranDetailViewModel : ObservableValidator
     [ObservableProperty]
     public int acCode;
     [ObservableProperty]
+    public int categoryCode;
+    [ObservableProperty]
+    public string? categoryHead;
+    [ObservableProperty]
     public double? cashAmount;
     [ObservableProperty]
     public double? adjAmount;

--- a/WpfCheckerView/ViewModels/FasHeadDemoViewModel.cs
+++ b/WpfCheckerView/ViewModels/FasHeadDemoViewModel.cs
@@ -5,38 +5,28 @@ namespace WpfCheckerView.ViewModels;
 
 public class FasHeadDemoViewModel
 {
+    public ObservableCollection<TranDetailViewModel> TranDetails { get; } = new();
     public ObservableCollection<FasHead> FasHeads { get; } = new();
+    public ObservableCollection<FasHeadSubCategories> FasHeadSubCategories { get; } = new();
 
     public FasHeadDemoViewModel()
     {
-        FasHeads.Add(new FasHead
-        {
-            FasCode = 1,
-            FasName = "Share Capital A Class",
-            CategoryCode = 1,
-            CategoryHead = "Agent Name",
-            AdjAmount = 1000
-        });
+        FasHeads.Add(new FasHead { FasCode = 1, FasName = "Share Capital A Class", CategoryCode = 1, CategoryHead = "Agent Name" });
+        FasHeads.Add(new FasHead { FasCode = 2, FasName = "Loan to Members Ordinary", CategoryCode = 2, CategoryHead = "Agent Name" });
+        FasHeads.Add(new FasHead { FasCode = 3, FasName = "Interest on Loans Ordinary", CategoryCode = 3, CategoryHead = "Due-by Head" });
 
-        var loanHead = new FasHead
-        {
-            FasCode = 2,
-            FasName = "Loan to Members Ordinary",
-            CategoryCode = 2,
-            CategoryHead = "Agent Name"
-        };
-        loanHead.SubHeads.Add(new FasHeadSubCategory { SubCode = 201, SubName = "Member A", Amount = 300 });
-        loanHead.SubHeads.Add(new FasHeadSubCategory { SubCode = 202, SubName = "Member B", Amount = 200 });
-        FasHeads.Add(loanHead);
+        FasHeadSubCategories.Add(new FasHeadSubCategories { SubCode = 201, SubName = "Member A", CategoryCode = 2, CategoryHead = "Agent Name", SelectedBranch = "Main" });
+        FasHeadSubCategories.Add(new FasHeadSubCategories { SubCode = 202, SubName = "Member B", CategoryCode = 2, CategoryHead = "Agent Name", SelectedBranch = "Main" });
 
-        FasHeads.Add(new FasHead
-        {
-            FasCode = 3,
-            FasName = "Interest on Loans Ordinary",
-            CategoryCode = 2,
-            CategoryHead = "Due-by Head",
-            AdjAmount = 150
-        });
+        var detail1 = new TranDetailViewModel { AcCode = 1, CategoryCode = 1, CategoryHead = "Agent Name", AdjAmount = 1000 };
+        TranDetails.Add(detail1);
+
+        var detail2 = new TranDetailViewModel { AcCode = 2, CategoryCode = 2, CategoryHead = "Agent Name" };
+        detail2.TranSubDetails.Add(new TranSubDetailViewModel { SubCode = 201, Amount = 300 });
+        detail2.TranSubDetails.Add(new TranSubDetailViewModel { SubCode = 202, Amount = 200 });
+        TranDetails.Add(detail2);
+
+        var detail3 = new TranDetailViewModel { AcCode = 3, CategoryCode = 3, CategoryHead = "Due-by Head", AdjAmount = 150 };
+        TranDetails.Add(detail3);
     }
 }
-

--- a/WpfCheckerView/Views/FasHeadDemoControl.xaml
+++ b/WpfCheckerView/Views/FasHeadDemoControl.xaml
@@ -14,15 +14,15 @@
     </UserControl.Resources>
     <Grid>
         <syncfusion:SfDataGrid x:Name="FasGrid"
-                               ItemsSource="{Binding FasHeads}"
+                               ItemsSource="{Binding TranDetails}"
                                AutoGenerateColumns="False"
                                ShowRowHeader="False"
                                NavigationMode="Cell">
             <syncfusion:SfDataGrid.Columns>
-                <syncfusion:GridComboBoxColumn MappingName="FasName" HeaderText="A/C Head" Width="{StaticResource ExpanderHeaderWidth}"
+                <syncfusion:GridComboBoxColumn MappingName="AcCode" HeaderText="A/C Head" Width="{StaticResource ExpanderHeaderWidth}"
                                                ItemsSource="{Binding FasHeads}"
-DisplayMemberPath="FasName"
-SelectedValuePath="FasCode" />
+                                               DisplayMemberPath="FasName"
+                                               SelectedValuePath="FasCode" />
                 <syncfusion:GridNumericColumn MappingName="AdjAmount" HeaderText="Adjustment" Width="{StaticResource AmountHeaderWidth}"/>
             </syncfusion:SfDataGrid.Columns>
             <!--<syncfusion:SfDataGrid.RowExpanderStyle>
@@ -37,18 +37,18 @@ SelectedValuePath="FasCode" />
             </syncfusion:SfDataGrid.RowExpanderStyle>-->
             <syncfusion:SfDataGrid.DetailsViewDefinition>
                 <syncfusion:GridViewDefinition>
-                    <syncfusion:GridViewDefinition.RelationalColumn>SubHeads</syncfusion:GridViewDefinition.RelationalColumn>
-                    <syncfusion:GridViewDefinition.DataGrid >
+                    <syncfusion:GridViewDefinition.RelationalColumn>TranSubDetails</syncfusion:GridViewDefinition.RelationalColumn>
+                    <syncfusion:GridViewDefinition.DataGrid>
                         <syncfusion:SfDataGrid AutoGenerateColumns="False"
                                                ShowRowHeader="False"
                                                NavigationMode="Cell" Height="300">
                             <syncfusion:SfDataGrid.Columns>
-                                <syncfusion:GridComboBoxColumn  Width="{StaticResource ExpanderHeaderWidth}"
-                                                                HeaderText="{Binding CategoryHead}"
-                                                                MappingName="SubCode"
- ItemsSource="{Binding FasHeads}"
- DisplayMemberPath="SubName"
- SelectedValuePath="SubCode"/>
+                                <syncfusion:GridComboBoxColumn Width="{StaticResource ExpanderHeaderWidth}"
+                                                               HeaderText="{Binding CategoryHead}"
+                                                               MappingName="SubCode"
+                                                               ItemsSource="{Binding DataContext.FasHeadSubCategories, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                               DisplayMemberPath="SubName"
+                                                               SelectedValuePath="SubCode"/>
                                 <syncfusion:GridNumericColumn MappingName="Amount" HeaderText="Amount" Width="{StaticResource AmountHeaderWidth}"/>
                             </syncfusion:SfDataGrid.Columns>
                         </syncfusion:SfDataGrid>

--- a/WpfCheckerView/Views/FasHeadDemoControl.xaml.cs
+++ b/WpfCheckerView/Views/FasHeadDemoControl.xaml.cs
@@ -1,7 +1,4 @@
 using System.Windows.Controls;
-using Syncfusion.UI.Xaml.Grid;
-using WpfCheckerView.Models;
-using WpfCheckerView.ViewModels;
 
 namespace WpfCheckerView.Views;
 
@@ -10,15 +7,5 @@ public partial class FasHeadDemoControl : UserControl
     public FasHeadDemoControl()
     {
         InitializeComponent();
-        //FasGrid.DetailsViewManager.QueryDetailsViewExpanding += DetailsViewManager_QueryDetailsViewExpanding;
     }
-
-    //private void DetailsViewManager_QueryDetailsViewExpanding(object? sender, QueryDetailsViewExpandingEventArgs e)
-    //{
-    //    if (e.Record is FasHead head && !head.HasSubHeads)
-    //    {
-    //        e.Cancel = true;
-    //    }
-    //}
 }
-


### PR DESCRIPTION
## Summary
- Bind main grid to `TranDetailViewModel` entries with nested `TranSubDetailViewModel` items
- Provide `FasHead` and `FasHeadSubCategories` collections for combobox columns
- Extend transaction detail model with category fields and sample data

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ea6ba9788325b398cce4e0c5f5c9