### PR TITLE
Bind transaction details and subhead data

### DIFF
--- a/WpfCheckerView/Models/TransactionDetail.cs
+++ b/WpfCheckerView/Models/TransactionDetail.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace WpfCheckerView.Models;
@@ -33,6 +34,23 @@ public partial class TranDetailViewModel : ObservableValidator
     public DateTime tranDate;
     [ObservableProperty]
     public int acCode;
+    partial void OnAcCodeChanged(int oldValue, int newValue)
+    {
+        if (FasHeads == null)
+            return;
+
+        var selected = FasHeads.FirstOrDefault(f => f.FasCode == newValue);
+        if (selected != null)
+        {
+            CategoryHead = selected.CategoryHead;
+            CategoryCode = selected.CategoryCode;
+        }
+        else
+        {
+            CategoryHead = null;
+            CategoryCode = 0;
+        }
+    }
     [ObservableProperty]
     public int categoryCode;
     partial void OnCategoryCodeChanged(int oldValue, int newValue)
@@ -79,6 +97,7 @@ public partial class TranDetailViewModel : ObservableValidator
             foreach (TranSubDetailViewModel item in e.NewItems)
             {
                 item.PropertyChanged += SubDetail_PropertyChanged;
+                item.FasHeadSubCategories = SubFasHeads;
             }
         }
         if (e.OldItems != null)
@@ -109,8 +128,22 @@ public partial class TranDetailViewModel : ObservableValidator
 
     private void CategoryCodeChange(int newValue)
     {
-        //ToDo: Implement the logic to handle category code change
-        // CategoryCode has changed, So update the SubFasHeads accordingly from GroupFasHeadSubCategories 
+        if (GroupFasHeadSubCategories != null &&
+            GroupFasHeadSubCategories.TryGetValue(newValue, out var subHeads))
+        {
+            SubFasHeads = new ObservableCollection<FasHeadSubCategories>(subHeads);
+            IsSubOptionsPresent = SubFasHeads.Any();
+        }
+        else
+        {
+            SubFasHeads = new ObservableCollection<FasHeadSubCategories>();
+            IsSubOptionsPresent = false;
+        }
+
+        foreach (var item in TranSubDetails)
+        {
+            item.FasHeadSubCategories = SubFasHeads;
+        }
     }
 
 }

--- a/WpfCheckerView/ViewModels/FasHeadDemoViewModel.cs
+++ b/WpfCheckerView/ViewModels/FasHeadDemoViewModel.cs
@@ -41,16 +41,21 @@ public partial class FasHeadDemoViewModel : ObservableValidator
 
         groupFasHeadSubCategories= GetSortedSubFasHeads(FullFasHeadSubCategories);
 
-        var detail1 = new TranDetailViewModel { AcCode = 1, CategoryCode = 1, CategoryHead = "Agent Name", AdjAmount = 1000, IsSubOptionsPresent=false };
+        var detail1 = new TranDetailViewModel { AdjAmount = 1000 };
+        UpdateTranDetail(detail1, FasHeads, groupFasHeadSubCategories);
+        detail1.AcCode = 1;
         TranDetails.Add(detail1);
 
-
-        var detail2 = new TranDetailViewModel { AcCode = 2, CategoryCode = 2, CategoryHead = "Agent Name", IsSubOptionsPresent = true };
+        var detail2 = new TranDetailViewModel();
+        UpdateTranDetail(detail2, FasHeads, groupFasHeadSubCategories);
+        detail2.AcCode = 2;
         detail2.TranSubDetails.Add(new TranSubDetailViewModel { SubCode = 201, Amount = 300 });
         detail2.TranSubDetails.Add(new TranSubDetailViewModel { SubCode = 202, Amount = 200 });
         TranDetails.Add(detail2);
 
-        var detail3 = new TranDetailViewModel { AcCode = 3, CategoryCode = 3, CategoryHead = "Due-by Head", AdjAmount = 150, IsSubOptionsPresent = false };
+        var detail3 = new TranDetailViewModel { AdjAmount = 150 };
+        UpdateTranDetail(detail3, FasHeads, groupFasHeadSubCategories);
+        detail3.AcCode = 3;
         TranDetails.Add(detail3);
     }
 

--- a/WpfCheckerView/Views/FasHeadDemoControl.xaml
+++ b/WpfCheckerView/Views/FasHeadDemoControl.xaml
@@ -20,33 +20,34 @@
                                NavigationMode="Cell">
             <syncfusion:SfDataGrid.Columns>
                 <syncfusion:GridComboBoxColumn MappingName="AcCode" HeaderText="A/C Head" Width="{StaticResource ExpanderHeaderWidth}"
-                                               ItemsSource="{Binding FasHeads}"
+                                               ItemsSource="{Binding DataContext.FasHeads, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                DisplayMemberPath="FasName"
                                                SelectedValuePath="FasCode" />
                 <syncfusion:GridNumericColumn MappingName="AdjAmount" HeaderText="Adjustment" Width="{StaticResource AmountHeaderWidth}"/>
             </syncfusion:SfDataGrid.Columns>
-            <!--<syncfusion:SfDataGrid.RowExpanderStyle>
+            <syncfusion:SfDataGrid.RowExpanderStyle>
                 <Style TargetType="syncfusion:GridRowExpanderCell">
-                    <Setter Property="Visibility" Value="Visible"/>
+                    <Setter Property="Visibility" Value="Collapsed"/>
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding Record.HasSubHeads}" Value="False">
-                            <Setter Property="Visibility" Value="Collapsed"/>
+                        <DataTrigger Binding="{Binding IsSubOptionsPresent}" Value="True">
+                            <Setter Property="Visibility" Value="Visible"/>
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>
-            </syncfusion:SfDataGrid.RowExpanderStyle>-->
+            </syncfusion:SfDataGrid.RowExpanderStyle>
             <syncfusion:SfDataGrid.DetailsViewDefinition>
                 <syncfusion:GridViewDefinition>
                     <syncfusion:GridViewDefinition.RelationalColumn>TranSubDetails</syncfusion:GridViewDefinition.RelationalColumn>
                     <syncfusion:GridViewDefinition.DataGrid>
                         <syncfusion:SfDataGrid AutoGenerateColumns="False"
                                                ShowRowHeader="False"
-                                               NavigationMode="Cell" Height="300">
+                                               NavigationMode="Cell" Height="300"
+                                               ItemsSource="{Binding TranSubDetails}">
                             <syncfusion:SfDataGrid.Columns>
                                 <syncfusion:GridComboBoxColumn Width="{StaticResource ExpanderHeaderWidth}"
-                                                               HeaderText="{Binding CategoryHead}"
+                                                               HeaderText="Sub Head"
                                                                MappingName="SubCode"
-                                                               ItemsSource="{Binding DataContext.FasHeadSubCategories, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                               ItemsSource="{Binding FasHeadSubCategories}"
                                                                DisplayMemberPath="SubName"
                                                                SelectedValuePath="SubCode"/>
                                 <syncfusion:GridNumericColumn MappingName="Amount" HeaderText="Amount" Width="{StaticResource AmountHeaderWidth}"/>


### PR DESCRIPTION
## Summary
- Bind main grid to transaction details and drive account head selection from shared FasHeads list
- Toggle row detail visibility based on IsSubOptionsPresent and wire sub-grid to sub detail data
- Update transaction view models to populate account metadata and propagate available sub categories

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7dc9333b083258fedd8f954d39f00