### PR TITLE
Show sub grid only when sub options exist

### DIFF
--- a/WpfCheckerView/Views/FasHeadDemoControl.xaml
+++ b/WpfCheckerView/Views/FasHeadDemoControl.xaml
@@ -26,12 +26,14 @@
                             AllowDeleting="True"
                             AutoGenerateColumns="False"
                             AllowFiltering="False"  FilterRowPosition="None"
-                            AddNewRowPosition="Bottom" EditTrigger="OnTap" 
-                            AllowGrouping="False" AllowSorting="False" 
-                            ShowRowHeader="True"  NavigationMode="Cell" >
+                            AddNewRowPosition="Bottom" EditTrigger="OnTap"
+                            AllowGrouping="False" AllowSorting="False"
+                            ShowRowHeader="True"  NavigationMode="Cell"
+                            DetailsViewExpanding="FasGrid_DetailsViewExpanding"
+                            QueryDetailsViewExpanderState="FasGrid_QueryDetailsViewExpanderState" >
             
             <nice:SfDataGridExt.Columns>
-                <syncfusion:GridComboBoxColumn MappingName="AcCode" 
+                <syncfusion:GridComboBoxColumn MappingName="AcCode"
                                                HeaderText="A/C Head"
                                                Width="{StaticResource ExpanderHeaderWidth}"
                                                ItemsSource="{Binding FasHeads}"
@@ -39,16 +41,6 @@
                                                SelectedValuePath="FasCode"/>
                 <syncfusion:GridNumericColumn MappingName="AdjAmount" HeaderText="Adjustment" Width="{StaticResource AmountHeaderWidth}"/>
             </nice:SfDataGridExt.Columns>
-            <!--<nice:SfDataGridExt.RowExpanderStyle>
-                <Style TargetType="syncfusion:GridRowExpanderCell">
-                    <Setter Property="Visibility" Value="Collapsed"/>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding IsSubOptionsPresent}" Value="True">
-                            <Setter Property="Visibility" Value="Visible"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </nice:SfDataGridExt.RowExpanderStyle>-->
             <nice:SfDataGridExt.DetailsViewDefinition>
                 <syncfusion:GridViewDefinition>
                     <syncfusion:GridViewDefinition.RelationalColumn>TranSubDetails</syncfusion:GridViewDefinition.RelationalColumn>

--- a/WpfCheckerView/Views/FasHeadDemoControl.xaml.cs
+++ b/WpfCheckerView/Views/FasHeadDemoControl.xaml.cs
@@ -1,4 +1,10 @@
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Windows;
 using System.Windows.Controls;
+using Syncfusion.UI.Xaml.Grid;
+using WpfCheckerView.Models;
+using WpfCheckerView.ViewModels;
 
 namespace WpfCheckerView.Views;
 
@@ -7,5 +13,69 @@ public partial class FasHeadDemoControl : UserControl
     public FasHeadDemoControl()
     {
         InitializeComponent();
+        DataContextChanged += FasHeadDemoControl_DataContextChanged;
+    }
+
+    private void FasHeadDemoControl_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        if (e.OldValue is FasHeadDemoViewModel oldVm)
+        {
+            oldVm.TranDetails.CollectionChanged -= TranDetails_CollectionChanged;
+            foreach (var item in oldVm.TranDetails)
+            {
+                item.PropertyChanged -= TranDetail_PropertyChanged;
+            }
+        }
+
+        if (e.NewValue is FasHeadDemoViewModel newVm)
+        {
+            newVm.TranDetails.CollectionChanged += TranDetails_CollectionChanged;
+            foreach (var item in newVm.TranDetails)
+            {
+                item.PropertyChanged += TranDetail_PropertyChanged;
+            }
+        }
+    }
+
+    private void TranDetails_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.NewItems != null)
+        {
+            foreach (TranDetailViewModel item in e.NewItems)
+            {
+                item.PropertyChanged += TranDetail_PropertyChanged;
+            }
+        }
+        if (e.OldItems != null)
+        {
+            foreach (TranDetailViewModel item in e.OldItems)
+            {
+                item.PropertyChanged -= TranDetail_PropertyChanged;
+            }
+        }
+    }
+
+    private void TranDetail_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TranDetailViewModel.IsSubOptionsPresent))
+        {
+            FasGrid.View?.Refresh();
+        }
+    }
+
+    private void FasGrid_DetailsViewExpanding(object sender, GridViewExpandingEventArgs e)
+    {
+        if (e.Record is TranDetailViewModel detail && !detail.IsSubOptionsPresent)
+        {
+            e.Cancel = true;
+        }
+    }
+
+    private void FasGrid_QueryDetailsViewExpanderState(object sender, QueryDetailsViewExpanderStateEventArgs e)
+    {
+        if (e.Record is TranDetailViewModel detail)
+        {
+            e.ExpanderVisibility = detail.IsSubOptionsPresent;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Track `IsSubOptionsPresent` changes and refresh the grid so expander icons update in real time
- Continue to hide or cancel details view for records lacking sub options

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1653dd3f083259569bd6b384403d1