### PR TITLE
Handle dynamic FasHead rows and sub detail setup

### DIFF
--- a/WpfCheckerView/Models/TransactionDetail.cs
+++ b/WpfCheckerView/Models/TransactionDetail.cs
@@ -40,16 +40,20 @@ public partial class TranDetailViewModel : ObservableValidator
             return;
 
         var selected = FasHeads.FirstOrDefault(f => f.FasCode == newValue);
-        if (selected != null)
+
+        CategoryHead = selected?.CategoryHead;
+
+        var newCategoryCode = selected?.CategoryCode ?? 0;
+        if (CategoryCode != newCategoryCode)
         {
-            CategoryHead = selected.CategoryHead;
-            CategoryCode = selected.CategoryCode;
+            CategoryCode = newCategoryCode;
         }
         else
         {
-            CategoryHead = null;
-            CategoryCode = 0;
+            CategoryCodeChange(newCategoryCode);
         }
+
+        TranSubDetails.Clear();
     }
     [ObservableProperty]
     public int categoryCode;

--- a/WpfCheckerView/ViewModels/FasHeadDemoViewModel.cs
+++ b/WpfCheckerView/ViewModels/FasHeadDemoViewModel.cs
@@ -39,24 +39,7 @@ public partial class FasHeadDemoViewModel : ObservableValidator
         FullFasHeadSubCategories.Add(new FasHeadSubCategories { SubCode = 206, SubName = "Loan", CategoryCode = 3, CategoryHead = "Due-by Head", SelectedBranch = "Main" });
         FullFasHeadSubCategories.Add(new FasHeadSubCategories { SubCode = 207, SubName = "GoldLoan", CategoryCode = 3, CategoryHead = "Due-by Head", SelectedBranch = "Main" });
 
-        groupFasHeadSubCategories= GetSortedSubFasHeads(FullFasHeadSubCategories);
-
-        var detail1 = new TranDetailViewModel { AdjAmount = 1000 };
-        UpdateTranDetail(detail1, FasHeads, groupFasHeadSubCategories);
-        detail1.AcCode = 1;
-        TranDetails.Add(detail1);
-
-        var detail2 = new TranDetailViewModel();
-        UpdateTranDetail(detail2, FasHeads, groupFasHeadSubCategories);
-        detail2.AcCode = 3;
-        detail2.TranSubDetails.Add(new TranSubDetailViewModel { SubCode = 201, Amount = 300, FasHeadSubCategories= detail2.SubFasHeads });
-        detail2.TranSubDetails.Add(new TranSubDetailViewModel { SubCode = 202, Amount = 200, FasHeadSubCategories = detail2.SubFasHeads });
-        TranDetails.Add(detail2);
-
-        var detail3 = new TranDetailViewModel { AdjAmount = 150 };
-        UpdateTranDetail(detail3, FasHeads, groupFasHeadSubCategories);
-        detail3.AcCode = 2;
-        TranDetails.Add(detail3);
+        groupFasHeadSubCategories = GetSortedSubFasHeads(FullFasHeadSubCategories);
     }
 
     private Dictionary<int, IList<FasHeadSubCategories>> GetSortedSubFasHeads(IList<FasHeadSubCategories> fullSubFasHeads)
@@ -89,9 +72,11 @@ public partial class FasHeadDemoViewModel : ObservableValidator
                 break;
 
             case TranSubDetailViewModel tranSubDetailViewModel:
-                //UpdateSubTranDetail(property);
-                //SetFormDetailsTochildViewModel(property);
-                break;            
+                if (eventDetails.OriginalSender is SfDataGrid grid && grid.DataContext is TranDetailViewModel parent)
+                {
+                    tranSubDetailViewModel.FasHeadSubCategories = parent.SubFasHeads;
+                }
+                break;
 
             default:
                 // Handle unknown types or log as needed


### PR DESCRIPTION
## Summary
- preload only FasHeads and subcategory collections in demo view model
- wire AddNewRow to seed new detail and sub-detail rows with appropriate lookup collections
- refresh sub options and clear sub-details when account code changes

## Testing
- `dotnet test -p:EnableWindowsTargeting=true --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68c1b2fd5db88325bf72dd3bc4b47cfd