### PR TITLE
Enable vertical cell merging in SfDataGrid

### DIFF
--- a/WpfCheckerView/Views/MainWindow.xaml
+++ b/WpfCheckerView/Views/MainWindow.xaml
@@ -75,7 +75,7 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <nice:SfDataGridExt Grid.Row="0" x:Name="dataGrid" AutoGenerateColumns="True"
+            <nice:SfDataGridExt Grid.Row="0" x:Name="dataGrid" AutoGenerateColumns="True" QueryCoveredRange="DataGrid_QueryCoveredRange"
                                    ItemsSource="{Binding Employees}"
                                   AllowEditing="True"                                           
                                 AllowDeleting="True" 

--- a/WpfCheckerView/Views/MainWindow.xaml.cs
+++ b/WpfCheckerView/Views/MainWindow.xaml.cs
@@ -2,6 +2,9 @@ using System.Windows;
 using WpfCheckerView.ViewModels;
 using WpfCheckerView.Services;
 using Syncfusion.SfSkinManager;
+using Syncfusion.UI.Xaml.Grid;
+using Syncfusion.UI.Xaml.CellGrid;
+using WpfCheckerView.Models;
 
 namespace WpfCheckerView.Views
 {
@@ -23,6 +26,50 @@ namespace WpfCheckerView.Views
         private void SetDefaultFocus()
         {
             idTextBox.Focus();
+        }
+
+        private void DataGrid_QueryCoveredRange(object? sender, GridQueryCoveredRangeEventArgs e)
+        {
+            if (e.RowColumnIndex.RowIndex <= 0 || e.RowColumnIndex.ColumnIndex <= 0)
+                return;
+
+            var column = dataGrid.Columns[e.RowColumnIndex.ColumnIndex - 1];
+            if (column == null)
+                return;
+
+            if (column.MappingName == nameof(Employee.Id) || column.MappingName == nameof(Employee.Name))
+                return;
+
+            var records = dataGrid.View.Records;
+            var provider = dataGrid.View.GetPropertyAccessProvider();
+            int rowIndex = e.RowColumnIndex.RowIndex;
+            int recordIndex = rowIndex - 1;
+
+            var value = provider.GetValue(records[recordIndex].Data, column.MappingName);
+
+            int start = rowIndex;
+            for (int i = recordIndex - 1; i >= 0; i--)
+            {
+                var prev = provider.GetValue(records[i].Data, column.MappingName);
+                if (!Equals(prev, value))
+                    break;
+                start--;
+            }
+
+            int end = rowIndex;
+            for (int i = recordIndex + 1; i < records.Count; i++)
+            {
+                var next = provider.GetValue(records[i].Data, column.MappingName);
+                if (!Equals(next, value))
+                    break;
+                end++;
+            }
+
+            if (end > start)
+            {
+                e.Range = new CoveredCellInfo(start, e.RowColumnIndex.ColumnIndex, end, e.RowColumnIndex.ColumnIndex);
+                e.Handled = true;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Merge identical consecutive values vertically in SfDataGrid columns using QueryCoveredRange
- Keep ID and Name columns unmerged

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bd0d77808325b1923fc7b29a0cda