### PR TITLE
Add row merging support to SfDataGridExt

### DIFF
--- a/CustomControls/SfDataGridExt.cs
+++ b/CustomControls/SfDataGridExt.cs
@@ -1,13 +1,12 @@
-﻿using Syncfusion.UI.Xaml.CellGrid;
+﻿using Syncfusion.Data;
+using Syncfusion.UI.Xaml.CellGrid;
 using Syncfusion.UI.Xaml.Grid;
 using Syncfusion.UI.Xaml.Grid.Cells;
 using Syncfusion.UI.Xaml.Utility;
-using System;
+using Syncfusion.Windows.Controls.Grid;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -56,7 +55,193 @@ namespace Nice
             {
                 throw externalExceptionThrownEventArgs.Exception;
             };
+            MergeIgnoredColumns = new List<string>();
         }
+
+        #region Row Merging Properties
+
+        public bool AllowRowMerging
+        {
+            get => (bool)GetValue(AllowRowMergingProperty);
+            set => SetValue(AllowRowMergingProperty, value);
+        }
+
+        public static readonly DependencyProperty AllowRowMergingProperty =
+            DependencyProperty.Register(nameof(AllowRowMerging), typeof(bool), typeof(SfDataGridExt),
+                new PropertyMetadata(false, OnAllowRowMergingChanged));
+
+        public string? MergeColumnName
+        {
+            get => (string?)GetValue(MergeColumnNameProperty);
+            set => SetValue(MergeColumnNameProperty, value);
+        }
+
+        public static readonly DependencyProperty MergeColumnNameProperty =
+            DependencyProperty.Register(nameof(MergeColumnName), typeof(string), typeof(SfDataGridExt));
+
+        public IList<string> MergeIgnoredColumns
+        {
+            get => (IList<string>)GetValue(MergeIgnoredColumnsProperty);
+            set => SetValue(MergeIgnoredColumnsProperty, value);
+        }
+
+        public static readonly DependencyProperty MergeIgnoredColumnsProperty =
+            DependencyProperty.Register(nameof(MergeIgnoredColumns), typeof(IList<string>), typeof(SfDataGridExt));
+
+        public static bool GetMergeColumn(DependencyObject obj) => (bool)obj.GetValue(MergeColumnProperty);
+        public static void SetMergeColumn(DependencyObject obj, bool value) => obj.SetValue(MergeColumnProperty, value);
+
+        public static readonly DependencyProperty MergeColumnProperty =
+            DependencyProperty.RegisterAttached("MergeColumn", typeof(bool), typeof(SfDataGridExt),
+                new PropertyMetadata(false, OnMergeColumnChanged));
+
+        private static void OnMergeColumnChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is GridColumn column && column.DataGrid is SfDataGridExt grid)
+            {
+                if ((bool)e.NewValue)
+                {
+                    grid.MergeColumnName = column.MappingName;
+                }
+                else if (grid.MergeColumnName == column.MappingName)
+                {
+                    grid.MergeColumnName = null;
+                }
+            }
+        }
+
+        public static bool GetMergeIgnored(DependencyObject obj) => (bool)obj.GetValue(MergeIgnoredProperty);
+        public static void SetMergeIgnored(DependencyObject obj, bool value) => obj.SetValue(MergeIgnoredProperty, value);
+
+        public static readonly DependencyProperty MergeIgnoredProperty =
+            DependencyProperty.RegisterAttached("MergeIgnored", typeof(bool), typeof(SfDataGridExt),
+                new PropertyMetadata(false, OnMergeIgnoredChanged));
+
+        private static void OnMergeIgnoredChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is GridColumn column && column.DataGrid is SfDataGridExt grid)
+            {
+                if ((bool)e.NewValue)
+                {
+                    if (!grid.MergeIgnoredColumns.Contains(column.MappingName))
+                        grid.MergeIgnoredColumns.Add(column.MappingName);
+                }
+                else
+                {
+                    if (grid.MergeIgnoredColumns.Contains(column.MappingName))
+                        grid.MergeIgnoredColumns.Remove(column.MappingName);
+                }
+            }
+        }
+
+        private IPropertyAccessProvider? _propertyAccessor;
+
+        private static void OnAllowRowMergingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var grid = (SfDataGridExt)d;
+            bool enabled = (bool)e.NewValue;
+            if (enabled)
+            {
+                grid.ItemsSourceChanged += grid.OnItemsSourceChanged;
+                grid.QueryCoveredRange += grid.OnQueryCoveredRange;
+            }
+            else
+            {
+                grid.ItemsSourceChanged -= grid.OnItemsSourceChanged;
+                grid.QueryCoveredRange -= grid.OnQueryCoveredRange;
+            }
+        }
+
+        private void OnItemsSourceChanged(object? sender, GridItemsSourceChangedEventArgs e)
+        {
+            _propertyAccessor = View != null ? View.GetPropertyAccessProvider() : null;
+        }
+
+        private void OnQueryCoveredRange(object? sender, GridQueryCoveredRangeEventArgs e)
+        {
+            if (!AllowRowMerging || string.IsNullOrEmpty(MergeColumnName))
+                return;
+
+            var range = GetMergeRange(e.GridColumn, e.RowColumnIndex.RowIndex, e.RowColumnIndex.ColumnIndex, e.Record);
+            if (range == null)
+                return;
+
+            if (!CoveredCells.IsInRange(range))
+            {
+                e.Range = range;
+                e.Handled = true;
+            }
+        }
+
+        private CoveredCellInfo? GetMergeRange(GridColumn column, int rowIndex, int columnIndex, object rowData)
+        {
+            if (IsIgnoredColumn(column))
+                return null;
+
+            int recordsCount = GroupColumnDescriptions.Count != 0
+                ? View.TopLevelGroup.DisplayElements.Count + TableSummaryRows.Count + UnBoundRows.Count + (AddNewRowPosition == AddNewRowPosition.Top ? +1 : 0)
+                : View.Records.Count + TableSummaryRows.Count + UnBoundRows.Count + (AddNewRowPosition == AddNewRowPosition.Top ? +1 : 0);
+
+            var currentId = _propertyAccessor?.GetFormattedValue(rowData, MergeColumnName);
+            var startIndex = ResolveStartIndexBasedOnPosition();
+
+            int startRow = FindStartRow(rowIndex, startIndex, currentId);
+            int endRow = FindEndRow(rowIndex, recordsCount, currentId);
+
+            return (startRow != rowIndex || endRow != rowIndex)
+                ? new CoveredCellInfo(columnIndex, columnIndex, startRow, endRow)
+                : null;
+        }
+
+        private int FindStartRow(int rowIndex, int startIndex, object currentId)
+        {
+            for (int i = rowIndex - 1; i >= startIndex; i--)
+            {
+                var previousData = GetRecordEntryAtRowIndex(i);
+                if (previousData == null || !previousData.IsRecords)
+                    break;
+
+                var previousId = _propertyAccessor?.GetFormattedValue((previousData as RecordEntry).Data, MergeColumnName);
+                if (previousId == null || !previousId.Equals(currentId))
+                    break;
+
+                rowIndex = i;
+            }
+
+            return rowIndex;
+        }
+
+        private int FindEndRow(int rowIndex, int recordsCount, object currentId)
+        {
+            for (int i = rowIndex + 1; i < recordsCount + 1; i++)
+            {
+                var nextData = GetRecordEntryAtRowIndex(i);
+                if (nextData == null || !nextData.IsRecords)
+                    break;
+
+                var nextId = _propertyAccessor?.GetFormattedValue((nextData as RecordEntry).Data, MergeColumnName);
+                if (nextId == null || !nextId.Equals(currentId))
+                    break;
+
+                rowIndex = i;
+            }
+
+            return rowIndex;
+        }
+
+        private bool IsIgnoredColumn(GridColumn column)
+        {
+            if (MergeIgnoredColumns == null)
+                return false;
+            foreach (var name in MergeIgnoredColumns)
+            {
+                if (column.MappingName == name)
+                    return true;
+            }
+            return false;
+        }
+
+        #endregion
 
         protected override void OnTextInput(TextCompositionEventArgs e)
         {

--- a/WpfCheckerView/Views/MainWindow.md
+++ b/WpfCheckerView/Views/MainWindow.md
@@ -1,25 +1,19 @@
 # MainWindow Process Flow
 
-The `MainWindow` class hosts the application's data-entry form and a Syncfusion `SfDataGrid` that displays employees.
-This document outlines the high-level flow that occurs when the window is created and how the grid merges rows with
-identical employee identifiers.
+The `MainWindow` class hosts the application's data-entry form and a `SfDataGridExt`
+that displays employees. The extended grid merges rows based on declarative
+configuration and requires no code-behind logic.
 
 ## Initialization
 1. **Component setup** – WPF components are created and Syncfusion styles are applied.
 2. **View model wiring** – A `MockDataService` supplies data to a `MainViewModel` which becomes the `DataContext`.
 3. **Default focus** – The employee ID `TextBox` receives initial focus for quick input.
-4. **Grid event subscription** – The grid subscribes to `ItemsSourceChanged` and `QueryCoveredRange` to enable
-   reflection and cell merging.
+4. **Grid configuration** – `SfDataGridExt` exposes `AllowRowMerging`, `MergeColumnName`, and
+   `MergeIgnoredColumns`. In XAML, the merge column and ignored columns are marked with
+   `MergeColumn="True"` or `MergeIgnored="True"` attached properties.
 
-## Event Flow
-- `ItemsSourceChanged`: Captures an `IPropertyAccessProvider` used to read property values from grid records.
-- `QueryCoveredRange`: Executes before each cell is drawn. The handler calls `GetMergeRange` which searches adjacent
-  rows for matching IDs and returns a `CoveredCellInfo` so the grid renders a single merged cell.
-
-## Cell Merging Algorithm
-1. Skip processing if the column is marked as non-mergeable.
-2. Determine the total number of visible rows and current record identifier.
-3. Walk upward and downward from the current row gathering contiguous rows that share the same identifier.
-4. If multiple rows are found, return a `CoveredCellInfo` describing the span; otherwise no merge is applied.
-
-This flow keeps the UI responsive while clearly displaying groups of employees who share the same ID.
+## Row Merging
+When `AllowRowMerging` is enabled the control merges adjacent rows that share the
+same value in the configured merge column. Columns flagged with `MergeIgnored` are
+excluded from the span. This encapsulation keeps the UI responsive while clearly
+displaying groups of employees who share the same identifier.

--- a/WpfCheckerView/Views/MainWindow.xaml
+++ b/WpfCheckerView/Views/MainWindow.xaml
@@ -75,13 +75,14 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <syncfusion:SfDataGrid Grid.Row="0" x:Name="empDataGrid" 
-                                   ItemsSource="{Binding Employees}"  
-                                    SelectionUnit="Cell"
-                                   AllowEditing="True"
-                       NavigationMode="Cell">
-                <syncfusion:SfDataGrid.Columns>
-                    <syncfusion:GridTextColumn MappingName="Id" HeaderText="ID" />
+            <nice:SfDataGridExt Grid.Row="0" x:Name="empDataGrid"
+                                ItemsSource="{Binding Employees}"
+                                SelectionUnit="Cell"
+                                AllowEditing="True"
+                                NavigationMode="Cell"
+                                AllowRowMerging="True">
+                <nice:SfDataGridExt.Columns>
+                    <syncfusion:GridTextColumn MappingName="Id" HeaderText="ID" nice:SfDataGridExt.MergeColumn="True" />
                     <syncfusion:GridTextColumn MappingName="Name" HeaderText="Name" />
                     <syncfusion:GridComboBoxColumn
                         MappingName="Department"
@@ -89,13 +90,13 @@
                         ItemsSource="{Binding DataContext.Departments, RelativeSource={RelativeSource AncestorType=Window}}"
                         DisplayMemberPath="Name"
                         SelectedValuePath="Name" />
-                    <syncfusion:GridTextColumn MappingName="Salary" HeaderText="Salary" />
-                    <syncfusion:GridTextColumn MappingName="IdProof" HeaderText="ID Proof" />
+                    <syncfusion:GridTextColumn MappingName="Salary" HeaderText="Salary" nice:SfDataGridExt.MergeIgnored="True" />
+                    <syncfusion:GridTextColumn MappingName="IdProof" HeaderText="ID Proof" nice:SfDataGridExt.MergeIgnored="True" />
                     <syncfusion:GridTextColumn MappingName="PanNo" HeaderText="Pan No" />
                     <syncfusion:GridCheckBoxColumn MappingName="Status" HeaderText="Status" Width="50" />
-                    
-                </syncfusion:SfDataGrid.Columns>
-            </syncfusion:SfDataGrid>
+
+                </nice:SfDataGridExt.Columns>
+            </nice:SfDataGridExt>
             <local:FasHeadDemoControl  Grid.Row="1" Height="50" DataContext="{Binding FasHeadDemo}" />
             <!--<local:PaymentBalanceControl  Grid.Row="1" Height="350" DataContext="{Binding PaymentBalance}" />-->
             <!--<Expander Grid.Row="1" Header="Payment Methods">

--- a/WpfCheckerView/Views/MainWindow.xaml.cs
+++ b/WpfCheckerView/Views/MainWindow.xaml.cs
@@ -1,42 +1,17 @@
-using Syncfusion.Data;
 using Syncfusion.SfSkinManager;
-using Syncfusion.UI.Xaml.Grid;
-using Syncfusion.UI.Xaml.Grid.Helpers;
-using Syncfusion.Windows.Controls.Grid;
 using System.Windows;
-using System.Windows.Controls;
-using WpfCheckerView.Models;
 using WpfCheckerView.Services;
 using WpfCheckerView.ViewModels;
-using GridQueryCoveredRangeEventArgs = Syncfusion.UI.Xaml.Grid.GridQueryCoveredRangeEventArgs;
 
 namespace WpfCheckerView.Views
 {
     /// <summary>
     /// Main application window that hosts the employee entry form and data grid.
-    /// <para>
-    /// The constructor wires up Syncfusion themes, creates the <see cref="MainViewModel"/>
-    /// with a <see cref="MockDataService"/> and configures the grid to merge cells with
-    /// identical employee IDs. The process flow is as follows:
-    /// <list type="number">
-    /// <item><description>Initialize WPF components and apply global themes.</description></item>
-    /// <item><description>Create the view model and set it as the <see cref="Window.DataContext"/>.</description></item>
-    /// <item><description>Assign focus to the ID text box for quick data entry.</description></item>
-    /// <item><description>Hook grid events that provide cell merging and property reflection.</description></item>
-    /// </list>
-    /// </para>
+    /// The grid relies on <see cref="CustomControls.SfDataGridExt"/> to provide
+    /// automatic row merging without any code-behind configuration.
     /// </summary>
     public partial class MainWindow : Window
     {
-        private readonly SfDataGrid _dataGrid;
-        private readonly string _mergeColumnName = nameof(Employee.Id);
-        private readonly string[] _ignoredColumns =
-        {
-            nameof(Employee.Department),
-            nameof(Employee.Salary)
-        };
-        private IPropertyAccessProvider _propertyAccessor;
-
         public MainWindow()
         {
             InitializeComponent();
@@ -44,123 +19,8 @@ namespace WpfCheckerView.Views
 
             var dataService = new MockDataService();
             DataContext = new MainViewModel(dataService, dataService);
-            SetDefaultFocus();
-
-            _dataGrid = empDataGrid;
-            _dataGrid.ItemsSourceChanged += OnItemsSourceChanged;
-            _dataGrid.QueryCoveredRange += OnQueryCoveredRange;
-            // _dataGrid.SelectionUnit = GridSelectionUnit.Cell;
-            // _dataGrid.NavigationMode = Syncfusion.UI.Xaml.Grid.NavigationMode.Cell;
-        }
-
-        private void SetDefaultFocus() => idTextBox.Focus();
-
-        /// <summary>
-        /// Handles the <see cref="SfDataGrid.ItemsSourceChanged"/> event and captures
-        /// a property accessor for reflection-based value comparisons.
-        /// </summary>
-        private void OnItemsSourceChanged(object sender, GridItemsSourceChangedEventArgs e)
-        {
-            _propertyAccessor = _dataGrid.View != null
-                ? _dataGrid.View.GetPropertyAccessProvider()
-                : null;
-        }
-
-        /// <summary>
-        /// Handles the <see cref="SfDataGrid.QueryCoveredRange"/> event to merge
-        /// adjacent rows with identical values in the configured column.
-        /// </summary>
-        private void OnQueryCoveredRange(object sender, GridQueryCoveredRangeEventArgs e)
-        {
-            var range = GetMergeRange(
-                e.GridColumn,
-                e.RowColumnIndex.RowIndex,
-                e.RowColumnIndex.ColumnIndex,
-                e.Record);
-
-            if (range == null)
-                return;
-
-            // Only assign the range if it is not already covered.
-            if (!_dataGrid.CoveredCells.IsInRange(range))
-            {
-                e.Range = range;
-                e.Handled = true;
-            }
-        }
-
-        /// <summary>
-        /// Determines the range of rows that should be merged for the specified cell.
-        /// </summary>
-        /// <param name="column">Column that contains the current cell.</param>
-        /// <param name="rowIndex">Row index of the current cell.</param>
-        /// <param name="columnIndex">Column index of the current cell.</param>
-        /// <param name="rowData">Data object associated with the current row.</param>
-        /// <returns>A <see cref="CoveredCellInfo"/> representing the merge range; otherwise, <c>null</c>.</returns>
-        private CoveredCellInfo GetMergeRange(GridColumn column, int rowIndex, int columnIndex, object rowData)
-        {
-            if (IsIgnoredColumn(column))
-                return null;
-
-            int recordsCount = _dataGrid.GroupColumnDescriptions.Count != 0
-                ? _dataGrid.View.TopLevelGroup.DisplayElements.Count + _dataGrid.TableSummaryRows.Count + _dataGrid.UnBoundRows.Count + (_dataGrid.AddNewRowPosition == AddNewRowPosition.Top ? +1 : 0)
-                : _dataGrid.View.Records.Count + _dataGrid.TableSummaryRows.Count + _dataGrid.UnBoundRows.Count + (_dataGrid.AddNewRowPosition == AddNewRowPosition.Top ? +1 : 0);
-
-            var currentId = _propertyAccessor.GetFormattedValue(rowData, _mergeColumnName);
-            var startIndex = _dataGrid.ResolveStartIndexBasedOnPosition();
-
-            int startRow = FindStartRow(rowIndex, startIndex, currentId);
-            int endRow = FindEndRow(rowIndex, recordsCount, currentId);
-
-            return (startRow != rowIndex || endRow != rowIndex)
-                ? new CoveredCellInfo(columnIndex, columnIndex, startRow, endRow)
-                : null;
-        }
-
-        private int FindStartRow(int rowIndex, int startIndex, object currentId)
-        {
-            for (int i = rowIndex - 1; i >= startIndex; i--)
-            {
-                var previousData = _dataGrid.GetRecordEntryAtRowIndex(i);
-                if (previousData == null || !previousData.IsRecords)
-                    break;
-
-                var previousId = _propertyAccessor.GetFormattedValue((previousData as RecordEntry).Data, _mergeColumnName);
-                if (previousId == null || !previousId.Equals(currentId))
-                    break;
-
-                rowIndex = i;
-            }
-
-            return rowIndex;
-        }
-
-        private int FindEndRow(int rowIndex, int recordsCount, object currentId)
-        {
-            for (int i = rowIndex + 1; i < recordsCount + 1; i++)
-            {
-                var nextData = _dataGrid.GetRecordEntryAtRowIndex(i);
-                if (nextData == null || !nextData.IsRecords)
-                    break;
-
-                var nextId = _propertyAccessor.GetFormattedValue((nextData as RecordEntry).Data, _mergeColumnName);
-                if (nextId == null || !nextId.Equals(currentId))
-                    break;
-
-                rowIndex = i;
-            }
-
-            return rowIndex;
-        }
-
-        private bool IsIgnoredColumn(GridColumn column)
-        {
-            foreach (var name in _ignoredColumns)
-            {
-                if (column.MappingName == name)
-                    return true;
-            }
-            return false;
+            idTextBox.Focus();
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- extend SfDataGridExt with row merging capability via AllowRowMerging, MergeColumnName, and MergeIgnoredColumns
- allow columns to opt-in through MergeColumn/MergeIgnored attached properties
- update MainWindow to use SfDataGridExt for merging and refresh documentation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c30f9d619c8325bf26c33e48be384c