### PR TITLE
Refresh FasGrid expander when sub options change

### DIFF
--- a/WpfCheckerView/Views/FasHeadDemoControl.xaml.cs
+++ b/WpfCheckerView/Views/FasHeadDemoControl.xaml.cs
@@ -13,55 +13,56 @@ public partial class FasHeadDemoControl : UserControl
     public FasHeadDemoControl()
     {
         InitializeComponent();
-        //DataContextChanged += FasHeadDemoControl_DataContextChanged;
+        DataContextChanged += FasHeadDemoControl_DataContextChanged;
     }
 
-    //private void FasHeadDemoControl_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
-    //{
-    //    if (e.OldValue is FasHeadDemoViewModel oldVm)
-    //    {
-    //        oldVm.TranDetails.CollectionChanged -= TranDetails_CollectionChanged;
-    //        foreach (var item in oldVm.TranDetails)
-    //        {
-    //            item.PropertyChanged -= TranDetail_PropertyChanged;
-    //        }
-    //    }
+    private void FasHeadDemoControl_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        if (e.OldValue is FasHeadDemoViewModel oldVm)
+        {
+            oldVm.TranDetails.CollectionChanged -= TranDetails_CollectionChanged;
+            foreach (var item in oldVm.TranDetails)
+            {
+                item.PropertyChanged -= TranDetail_PropertyChanged;
+            }
+        }
 
-    //    if (e.NewValue is FasHeadDemoViewModel newVm)
-    //    {
-    //        newVm.TranDetails.CollectionChanged += TranDetails_CollectionChanged;
-    //        foreach (var item in newVm.TranDetails)
-    //        {
-    //            item.PropertyChanged += TranDetail_PropertyChanged;
-    //        }
-    //    }
-    //}
+        if (e.NewValue is FasHeadDemoViewModel newVm)
+        {
+            newVm.TranDetails.CollectionChanged += TranDetails_CollectionChanged;
+            foreach (var item in newVm.TranDetails)
+            {
+                item.PropertyChanged += TranDetail_PropertyChanged;
+            }
+        }
+    }
 
-    //private void TranDetails_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
-    //{
-    //    if (e.NewItems != null)
-    //    {
-    //        foreach (TranDetailViewModel item in e.NewItems)
-    //        {
-    //            item.PropertyChanged += TranDetail_PropertyChanged;
-    //        }
-    //    }
-    //    if (e.OldItems != null)
-    //    {
-    //        foreach (TranDetailViewModel item in e.OldItems)
-    //        {
-    //            item.PropertyChanged -= TranDetail_PropertyChanged;
-    //        }
-    //    }
-    //}
+    private void TranDetails_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.NewItems != null)
+        {
+            foreach (TranDetailViewModel item in e.NewItems)
+            {
+                item.PropertyChanged += TranDetail_PropertyChanged;
+            }
+        }
+        if (e.OldItems != null)
+        {
+            foreach (TranDetailViewModel item in e.OldItems)
+            {
+                item.PropertyChanged -= TranDetail_PropertyChanged;
+            }
+        }
+    }
 
-    //private void TranDetail_PropertyChanged(object? sender, PropertyChangedEventArgs e)
-    //{
-    //    if (e.PropertyName == nameof(TranDetailViewModel.IsSubOptionsPresent))
-    //    {
-    //        FasGrid.View?.Refresh();
-    //    }
-    //}
+    private void TranDetail_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TranDetailViewModel.IsSubOptionsPresent))
+        {
+            // Refresh the grid so expander visibility updates for the affected row
+            FasGrid.View?.Refresh();
+        }
+    }
 
 
     private void FasGrid_QueryDetailsViewExpanderState(object sender, QueryDetailsViewExpanderStateEventArgs e)


### PR DESCRIPTION
## Summary
- Attach to view model collection and property changes in `FasHeadDemoControl` to track `IsSubOptionsPresent`
- Refresh the grid when the flag changes so row expander visibility updates dynamically

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d8c994748325916832c75ee63ef1