### PR TITLE
Allow clearing ComboBox selections

### DIFF
--- a/WpfCheckerView/Models/DTOClass.cs
+++ b/WpfCheckerView/Models/DTOClass.cs
@@ -15,14 +15,14 @@ namespace WpfCheckerView.Models
 
         public string NewEmployeeDepartment { get; set; }
 
-        public int NewEmployeeDepartmentId { get; set; }
+        public int? NewEmployeeDepartmentId { get; set; }
 
-        public int NewEmployeeDepartmentId2 { get; set; }
+        public int? NewEmployeeDepartmentId2 { get; set; }
 
         public int? NewEmployeeDepartmentId3 { get; set; }
 
         public int? NewEmployeeDepartmentId4 { get; set; }
-        public int NewEmployeeDepartmentId5 { get; set; }
+        public int? NewEmployeeDepartmentId5 { get; set; }
 
         public string NewEmployeeSalary { get; set; }
 

--- a/WpfCheckerView/ViewModels/MainViewModel.cs
+++ b/WpfCheckerView/ViewModels/MainViewModel.cs
@@ -33,10 +33,10 @@ namespace WpfCheckerView.ViewModels
 
 
         [ObservableProperty]
-        private int newEmployeeDepartmentId;
+        private int? newEmployeeDepartmentId;
 
         [ObservableProperty]
-        private int newEmployeeDepartmentId2;
+        private int? newEmployeeDepartmentId2;
 
         [ObservableProperty]
         private string newEmployeeSalary = string.Empty;
@@ -108,8 +108,8 @@ namespace WpfCheckerView.ViewModels
             NewEmployeeSalary = string.Empty;
             NewEmployeeIdProof = string.Empty;
             NewEmployeePanNo = string.Empty;
-            NewEmployeeDepartmentId = 0;
-            NewEmployeeDepartmentId2 = 0;
+            NewEmployeeDepartmentId = null;
+            NewEmployeeDepartmentId2 = null;
             return;
             if (string.IsNullOrWhiteSpace(NewEmployeeId) ||
                 string.IsNullOrWhiteSpace(NewEmployeeName) ||


### PR DESCRIPTION
## Summary
- allow department id fields in the DTO to be nullable so ComboBoxAdvanced can clear their selection
- reset the view-model's backing fields to null when clearing the add-employee form

## Testing
- ❌ `dotnet test WpfChecker.sln` *(dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5262ba14832581830ca8275defa0